### PR TITLE
Add session settings drawer and player registration controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
-# pokerFace
+# Poker Night Tracker
+
+A lightweight, client-side web app to coordinate poker nights end-to-end. Hosts can configure the session, invite players to register themselves, and keep tabs on table totals, expenses, and outcomes. All data stays in the browser via `localStorage` so every host can quickly resume where they left off.
+
+## Features
+
+- Slide-out settings menu with host controls for name, location, session date/time, preferred currency (USD, EUR, or ILS), reported final cash, and table expenses.
+- Session status management so the administrator can open or close editing. Player inputs are locked and the add/remove buttons are disabled the moment a night is closed.
+- Shareable player registration link (`?role=player`) that reveals a streamlined view where guests can add themselves and update their buy-ins/final cash while the session is open.
+- Live summary showing total buy-ins, final cash, table delta (highlighted bright red when off), leftover cash after expenses, and win/loss counts.
+- Data automatically persists in the same browser via `localStorage` with a one-click reset when you need to start fresh.
+
+## Getting started
+
+Open `index.html` in any modern browser, or serve the repo locally:
+
+```bash
+python -m http.server 8000
+```
+
+Then navigate to http://localhost:8000.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,201 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Poker Face Tracker</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <button id="settings-toggle" class="settings-toggle" aria-label="Open settings">
+    <span></span>
+    <span></span>
+    <span></span>
+  </button>
+
+  <aside id="settings-panel" class="settings-panel" aria-hidden="true">
+    <div class="settings-header">
+      <h2>Session Settings</h2>
+      <button id="close-settings" class="ghost" aria-label="Close settings">Close</button>
+    </div>
+    <div class="settings-body">
+      <section aria-labelledby="host-settings-heading">
+        <h3 id="host-settings-heading">Host details</h3>
+        <label>
+          Host name
+          <input type="text" id="host-name" placeholder="e.g. Alex" />
+        </label>
+        <label>
+          Location
+          <input type="text" id="host-location" placeholder="e.g. Downtown Loft" />
+        </label>
+        <label>
+          Session date &amp; time
+          <input type="datetime-local" id="session-datetime" />
+        </label>
+        <label>
+          Currency
+          <select id="currency-select">
+            <option value="USD">USD ($)</option>
+            <option value="EUR">EUR (€)</option>
+            <option value="ILS">ILS (₪)</option>
+          </select>
+        </label>
+        <label>
+          Table expenses
+          <div class="currency-input">
+            <span class="currency-symbol">$</span>
+            <input type="number" id="table-expense" min="0" step="0.01" placeholder="0.00" />
+          </div>
+        </label>
+        <label>
+          Total final cash (reported)
+          <div class="currency-input">
+            <span class="currency-symbol">$</span>
+            <input type="number" id="reported-final" min="0" step="0.01" placeholder="0.00" />
+          </div>
+        </label>
+        <label>
+          Session status
+          <select id="session-status">
+            <option value="open">Open</option>
+            <option value="closed">Closed</option>
+          </select>
+        </label>
+      </section>
+      <section aria-labelledby="admin-actions-heading">
+        <h3 id="admin-actions-heading">Admin actions</h3>
+        <button id="reset-btn" class="ghost">Reset all data</button>
+        <p class="hint">Share this link so players can register: <span id="player-link"></span></p>
+      </section>
+    </div>
+  </aside>
+
+  <div id="settings-overlay" class="settings-overlay" aria-hidden="true"></div>
+
+  <main class="app">
+    <header>
+      <div>
+        <h1>Poker Night Tracker</h1>
+        <p class="subtitle">Track registrations, final cash, buy-ins, and table results for poker night.</p>
+      </div>
+      <div class="session-status" id="session-status-indicator">Session open</div>
+    </header>
+
+    <section class="card" aria-labelledby="event-heading">
+      <div class="section-header">
+        <h2 id="event-heading">Event details</h2>
+      </div>
+      <dl class="event-details">
+        <div>
+          <dt>Host</dt>
+          <dd id="display-host">—</dd>
+        </div>
+        <div>
+          <dt>Location</dt>
+          <dd id="display-location">—</dd>
+        </div>
+        <div>
+          <dt>Date &amp; time</dt>
+          <dd id="display-datetime">—</dd>
+        </div>
+        <div>
+          <dt>Reported final cash</dt>
+          <dd id="display-reported-final">$0.00</dd>
+        </div>
+        <div>
+          <dt>Table expenses</dt>
+          <dd id="display-expenses">$0.00</dd>
+        </div>
+      </dl>
+    </section>
+
+    <div id="player-mode-banner" class="player-banner" hidden>
+      <p>This is the player view. You can add yourself or update your numbers while the session is open.</p>
+    </div>
+
+    <section class="card" aria-labelledby="players-heading">
+      <div class="section-header">
+        <h2 id="players-heading">Players</h2>
+        <button id="add-player-btn" class="primary">Add Player</button>
+      </div>
+      <div class="table-wrapper">
+        <table>
+          <thead>
+            <tr>
+              <th scope="col">Player</th>
+              <th scope="col">Buy-ins (<span class="currency-symbol">$</span>)</th>
+              <th scope="col">Final cash (<span class="currency-symbol">$</span>)</th>
+              <th scope="col">Net result</th>
+              <th scope="col">Outcome</th>
+              <th scope="col" class="actions">Actions</th>
+            </tr>
+          </thead>
+          <tbody id="players-body">
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section class="card" aria-labelledby="summary-heading">
+      <h2 id="summary-heading">Summary</h2>
+      <div class="summary-grid" id="summary-grid" role="list">
+        <article class="summary-card" role="listitem">
+          <h3>Total buy-ins</h3>
+          <p id="total-buyins" class="metric">$0.00</p>
+        </article>
+        <article class="summary-card" role="listitem">
+          <h3>Total final cash</h3>
+          <p id="total-final" class="metric">$0.00</p>
+        </article>
+        <article class="summary-card" role="listitem">
+          <h3>Table delta</h3>
+          <p id="table-delta" class="metric">$0.00</p>
+          <p class="hint">(Final cash minus buy-ins)</p>
+        </article>
+        <article class="summary-card" role="listitem">
+          <h3>Expenses</h3>
+          <p id="summary-expenses" class="metric">$0.00</p>
+        </article>
+        <article class="summary-card" role="listitem">
+          <h3>Amount left after expenses</h3>
+          <p id="amount-left" class="metric">$0.00</p>
+        </article>
+        <article class="summary-card" role="listitem">
+          <h3>Wins / Losses</h3>
+          <p id="wins-losses" class="metric">0 / 0</p>
+        </article>
+      </div>
+    </section>
+  </main>
+
+  <template id="player-row-template">
+    <tr>
+      <td data-label="Player">
+        <input type="text" class="player-name" placeholder="Name" />
+      </td>
+      <td data-label="Buy-ins">
+        <div class="currency-input">
+          <span class="currency-symbol">$</span>
+          <input type="number" class="player-buyins" min="0" step="0.01" placeholder="0.00" />
+        </div>
+      </td>
+      <td data-label="Final cash">
+        <div class="currency-input">
+          <span class="currency-symbol">$</span>
+          <input type="number" class="player-final" min="0" step="0.01" placeholder="0.00" />
+        </div>
+      </td>
+      <td data-label="Net result" class="net-result">
+        $0.00
+      </td>
+      <td data-label="Outcome" class="outcome">–</td>
+      <td class="actions">
+        <button class="ghost remove-player">Remove</button>
+      </td>
+    </tr>
+  </template>
+
+  <script src="main.js" type="module"></script>
+</body>
+</html>

--- a/main.js
+++ b/main.js
@@ -1,0 +1,430 @@
+const settingsToggle = document.querySelector('#settings-toggle');
+const settingsPanel = document.querySelector('#settings-panel');
+const settingsOverlay = document.querySelector('#settings-overlay');
+const closeSettingsBtn = document.querySelector('#close-settings');
+
+const hostNameInput = document.querySelector('#host-name');
+const locationInput = document.querySelector('#host-location');
+const datetimeInput = document.querySelector('#session-datetime');
+const expenseInput = document.querySelector('#table-expense');
+const reportedFinalInput = document.querySelector('#reported-final');
+const currencySelect = document.querySelector('#currency-select');
+const sessionStatusSelect = document.querySelector('#session-status');
+
+const addPlayerBtn = document.querySelector('#add-player-btn');
+const playersBody = document.querySelector('#players-body');
+const resetBtn = document.querySelector('#reset-btn');
+const playerLinkSpan = document.querySelector('#player-link');
+const playerModeBanner = document.querySelector('#player-mode-banner');
+const sessionStatusIndicator = document.querySelector('#session-status-indicator');
+
+const totalBuyinsEl = document.querySelector('#total-buyins');
+const totalFinalEl = document.querySelector('#total-final');
+const tableDeltaEl = document.querySelector('#table-delta');
+const summaryExpensesEl = document.querySelector('#summary-expenses');
+const amountLeftEl = document.querySelector('#amount-left');
+const winsLossesEl = document.querySelector('#wins-losses');
+
+const displayHostEl = document.querySelector('#display-host');
+const displayLocationEl = document.querySelector('#display-location');
+const displayDatetimeEl = document.querySelector('#display-datetime');
+const displayReportedFinalEl = document.querySelector('#display-reported-final');
+const displayExpensesEl = document.querySelector('#display-expenses');
+
+const STORAGE_KEY = 'poker-night-tracker';
+const CURRENCY_SYMBOLS = {
+  USD: '$',
+  EUR: '€',
+  ILS: '₪',
+};
+
+const searchParams = new URLSearchParams(window.location.search);
+const isPlayerView = searchParams.get('role') === 'player';
+
+function getCurrencySymbol() {
+  return CURRENCY_SYMBOLS[currencySelect.value] ?? '$';
+}
+
+function formatCurrency(value) {
+  const number = Number(value) || 0;
+  const currency = currencySelect.value in CURRENCY_SYMBOLS ? currencySelect.value : 'USD';
+  return new Intl.NumberFormat(undefined, {
+    style: 'currency',
+    currency,
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(number);
+}
+
+function generateId() {
+  return `player-${Math.random().toString(36).slice(2)}-${Date.now()}`;
+}
+
+function getPlayersData() {
+  return Array.from(playersBody.querySelectorAll('tr')).map((row) => {
+    const name = row.querySelector('.player-name').value.trim();
+    const buyins = Number(row.querySelector('.player-buyins').value) || 0;
+    const final = Number(row.querySelector('.player-final').value) || 0;
+    return {
+      id: row.dataset.id,
+      name,
+      buyins,
+      final,
+    };
+  });
+}
+
+function persistState() {
+  const state = {
+    settings: {
+      hostName: hostNameInput.value,
+      location: locationInput.value,
+      datetime: datetimeInput.value,
+      expenses: expenseInput.value,
+      reportedFinal: reportedFinalInput.value,
+      currency: currencySelect.value,
+      sessionStatus: sessionStatusSelect.value,
+    },
+    players: getPlayersData(),
+  };
+
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+}
+
+function restoreState() {
+  const stored = localStorage.getItem(STORAGE_KEY);
+  if (!stored) return;
+
+  try {
+    const state = JSON.parse(stored);
+    const settings = state.settings ?? {};
+
+    hostNameInput.value = settings.hostName ?? '';
+    locationInput.value = settings.location ?? '';
+    datetimeInput.value = settings.datetime ?? '';
+    expenseInput.value = settings.expenses ?? '';
+    reportedFinalInput.value = settings.reportedFinal ?? '';
+
+    if (settings.currency && settings.currency in CURRENCY_SYMBOLS) {
+      currencySelect.value = settings.currency;
+    } else {
+      currencySelect.value = 'USD';
+    }
+
+    if (settings.sessionStatus === 'closed') {
+      sessionStatusSelect.value = 'closed';
+    } else {
+      sessionStatusSelect.value = 'open';
+    }
+
+    playersBody.innerHTML = '';
+    (state.players ?? []).forEach((player) => {
+      const row = createPlayerRow(player);
+      playersBody.appendChild(row);
+    });
+  } catch (error) {
+    console.error('Failed to restore tracker state', error);
+  }
+}
+
+function updateEventDetails() {
+  displayHostEl.textContent = hostNameInput.value.trim() || '—';
+  displayLocationEl.textContent = locationInput.value.trim() || '—';
+
+  if (datetimeInput.value) {
+    const date = new Date(datetimeInput.value);
+    if (!Number.isNaN(date.valueOf())) {
+      displayDatetimeEl.textContent = new Intl.DateTimeFormat(undefined, {
+        dateStyle: 'medium',
+        timeStyle: 'short',
+      }).format(date);
+    } else {
+      displayDatetimeEl.textContent = '—';
+    }
+  } else {
+    displayDatetimeEl.textContent = '—';
+  }
+
+  displayReportedFinalEl.textContent = formatCurrency(reportedFinalInput.value);
+  displayExpensesEl.textContent = formatCurrency(expenseInput.value);
+}
+
+function updateSessionStatusUI() {
+  const isClosed = sessionStatusSelect.value === 'closed';
+  if (sessionStatusIndicator) {
+    sessionStatusIndicator.textContent = isClosed ? 'Session closed' : 'Session open';
+    sessionStatusIndicator.classList.toggle('closed', isClosed);
+  }
+
+  const disablePlayerInputs = isClosed;
+  playersBody.querySelectorAll('input').forEach((input) => {
+    input.disabled = disablePlayerInputs;
+  });
+  playersBody.querySelectorAll('.remove-player').forEach((button) => {
+    button.disabled = disablePlayerInputs;
+    button.classList.toggle('disabled', disablePlayerInputs);
+  });
+
+  if (addPlayerBtn) {
+    addPlayerBtn.disabled = isClosed;
+    addPlayerBtn.classList.toggle('disabled', isClosed);
+  }
+}
+
+function updateCurrencySymbols() {
+  const symbol = getCurrencySymbol();
+  document.querySelectorAll('.currency-symbol').forEach((span) => {
+    span.textContent = symbol;
+  });
+  updateEventDetails();
+}
+
+function updateSummary() {
+  const players = getPlayersData();
+  const totalBuyins = players.reduce((sum, player) => sum + player.buyins, 0);
+  const totalFinal = players.reduce((sum, player) => sum + player.final, 0);
+  const expenses = Number(expenseInput.value) || 0;
+  const tableDelta = totalFinal - totalBuyins;
+  const amountLeft = totalFinal - expenses;
+  const wins = players.filter((player) => player.final - player.buyins > 0).length;
+  const losses = players.filter((player) => player.final - player.buyins < 0).length;
+
+  totalBuyinsEl.textContent = formatCurrency(totalBuyins);
+  totalFinalEl.textContent = formatCurrency(totalFinal);
+  tableDeltaEl.textContent = formatCurrency(tableDelta);
+  tableDeltaEl.classList.toggle('alert', Math.abs(tableDelta) > 0.0001);
+  summaryExpensesEl.textContent = formatCurrency(expenses);
+  amountLeftEl.textContent = formatCurrency(amountLeft);
+  winsLossesEl.textContent = `${wins} / ${losses}`;
+}
+
+function updatePlayerLink() {
+  if (!playerLinkSpan) return;
+  const url = new URL(window.location.href);
+  url.searchParams.set('role', 'player');
+  playerLinkSpan.innerHTML = `<a href="${url.toString()}" target="_blank" rel="noopener">${url.toString()}</a>`;
+}
+
+function attachInputListeners(element, handler) {
+  element.addEventListener('input', handler);
+  element.addEventListener('change', handler);
+}
+
+function handlePlayerInputChange(row) {
+  const buyinsInput = row.querySelector('.player-buyins');
+  const finalInput = row.querySelector('.player-final');
+  const nameInput = row.querySelector('.player-name');
+  const netCell = row.querySelector('.net-result');
+  const outcomeCell = row.querySelector('.outcome');
+
+  const buyins = Number(buyinsInput.value) || 0;
+  const final = Number(finalInput.value) || 0;
+  const net = final - buyins;
+
+  netCell.textContent = formatCurrency(net);
+  netCell.classList.remove('positive', 'negative');
+  outcomeCell.classList.remove('positive', 'negative');
+
+  if (net > 0) {
+    netCell.classList.add('positive');
+    outcomeCell.textContent = 'Win';
+    outcomeCell.classList.add('positive');
+  } else if (net < 0) {
+    netCell.classList.add('negative');
+    outcomeCell.textContent = 'Loss';
+    outcomeCell.classList.add('negative');
+  } else if (nameInput.value.trim()) {
+    outcomeCell.textContent = 'Break even';
+  } else {
+    outcomeCell.textContent = '–';
+  }
+
+  persistState();
+  updateSummary();
+}
+
+function createPlayerRow(player = {}) {
+  const template = document.querySelector('#player-row-template');
+  const row = template.content.firstElementChild.cloneNode(true);
+  row.dataset.id = player.id ?? generateId();
+
+  const nameInput = row.querySelector('.player-name');
+  const buyinsInput = row.querySelector('.player-buyins');
+  const finalInput = row.querySelector('.player-final');
+  const removeBtn = row.querySelector('.remove-player');
+
+  nameInput.value = player.name ?? '';
+  buyinsInput.value = player.buyins ?? '';
+  finalInput.value = player.final ?? '';
+
+  row.querySelectorAll('.currency-symbol').forEach((span) => {
+    span.textContent = getCurrencySymbol();
+  });
+
+  const updateRow = () => handlePlayerInputChange(row);
+
+  [nameInput, buyinsInput, finalInput].forEach((input) => {
+    input.addEventListener('input', updateRow);
+    input.addEventListener('change', updateRow);
+  });
+
+  removeBtn.addEventListener('click', () => {
+    if (isPlayerView) return;
+    row.remove();
+    persistState();
+    updateSummary();
+  });
+
+  if (isPlayerView) {
+    removeBtn.classList.add('hidden');
+  }
+
+  handlePlayerInputChange(row);
+
+  return row;
+}
+
+function refreshAllRows() {
+  playersBody.querySelectorAll('tr').forEach((row) => {
+    handlePlayerInputChange(row);
+  });
+}
+
+function resetAll() {
+  const confirmation = confirm('Reset host info and remove all players?');
+  if (!confirmation) {
+    return;
+  }
+
+  hostNameInput.value = '';
+  locationInput.value = '';
+  datetimeInput.value = '';
+  expenseInput.value = '';
+  reportedFinalInput.value = '';
+  currencySelect.value = 'USD';
+  sessionStatusSelect.value = 'open';
+
+  playersBody.innerHTML = '';
+  addPlayerRow();
+  persistState();
+  updateCurrencySymbols();
+  updateSummary();
+  updateEventDetails();
+  updateSessionStatusUI();
+}
+
+function addPlayerRow(player = {}) {
+  const row = createPlayerRow(player);
+  playersBody.appendChild(row);
+  return row;
+}
+
+function setupSettingsPanel() {
+  if (!settingsToggle || !settingsPanel || !settingsOverlay) {
+    return;
+  }
+
+  const openPanel = () => {
+    settingsPanel.classList.add('open');
+    settingsOverlay.classList.add('visible');
+    settingsPanel.setAttribute('aria-hidden', 'false');
+    settingsOverlay.setAttribute('aria-hidden', 'false');
+  };
+
+  const closePanel = () => {
+    settingsPanel.classList.remove('open');
+    settingsOverlay.classList.remove('visible');
+    settingsPanel.setAttribute('aria-hidden', 'true');
+    settingsOverlay.setAttribute('aria-hidden', 'true');
+  };
+
+  settingsToggle.addEventListener('click', () => {
+    const isOpen = settingsPanel.classList.contains('open');
+    if (isOpen) {
+      closePanel();
+    } else {
+      openPanel();
+    }
+  });
+
+  closeSettingsBtn?.addEventListener('click', closePanel);
+  settingsOverlay.addEventListener('click', closePanel);
+}
+
+function updateViewForRole() {
+  if (isPlayerView) {
+    settingsToggle?.classList.add('hidden');
+    settingsPanel?.classList.add('player-hidden');
+    playerModeBanner?.removeAttribute('hidden');
+    if (addPlayerBtn) {
+      addPlayerBtn.textContent = 'Register player';
+    }
+    if (resetBtn) {
+      resetBtn.disabled = true;
+      resetBtn.classList.add('disabled');
+    }
+  }
+}
+
+function init() {
+  restoreState();
+
+  if (playersBody.children.length === 0) {
+    addPlayerRow();
+  }
+
+  updateViewForRole();
+  setupSettingsPanel();
+  updateCurrencySymbols();
+  updateEventDetails();
+  updateSummary();
+  updateSessionStatusUI();
+  updatePlayerLink();
+
+  attachInputListeners(hostNameInput, () => {
+    updateEventDetails();
+    persistState();
+  });
+  attachInputListeners(locationInput, () => {
+    updateEventDetails();
+    persistState();
+  });
+  attachInputListeners(datetimeInput, () => {
+    updateEventDetails();
+    persistState();
+  });
+  attachInputListeners(expenseInput, () => {
+    updateEventDetails();
+    persistState();
+    updateSummary();
+  });
+  attachInputListeners(reportedFinalInput, () => {
+    updateEventDetails();
+    persistState();
+  });
+  attachInputListeners(currencySelect, () => {
+    updateCurrencySymbols();
+    refreshAllRows();
+    persistState();
+    updateSummary();
+  });
+  attachInputListeners(sessionStatusSelect, () => {
+    updateSessionStatusUI();
+    persistState();
+  });
+
+  addPlayerBtn?.addEventListener('click', () => {
+    const row = addPlayerRow();
+    if (sessionStatusSelect.value === 'closed') {
+      updateSessionStatusUI();
+      return;
+    }
+    row.querySelector('.player-name')?.focus();
+    persistState();
+    updateSummary();
+  });
+
+  resetBtn?.addEventListener('click', resetAll);
+}
+
+window.addEventListener('DOMContentLoaded', init);

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,416 @@
+:root {
+  --bg: #111827;
+  --card: #1f2937;
+  --card-alt: #111827;
+  --text: #f9fafb;
+  --muted: #9ca3af;
+  --accent: #8b5cf6;
+  --accent-dark: #7c3aed;
+  --danger: #f87171;
+  --success: #34d399;
+  --border: rgba(255, 255, 255, 0.08);
+  --radius: 12px;
+  font-size: 16px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: radial-gradient(circle at top, #1e293b, var(--bg));
+  color: var(--text);
+  min-height: 100vh;
+  padding: 1.5rem;
+  position: relative;
+}
+
+main.app {
+  max-width: 1100px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding-bottom: 0.5rem;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(2rem, 2.7vw, 2.75rem);
+}
+
+.subtitle {
+  color: var(--muted);
+  margin-top: 0.5rem;
+}
+
+.card {
+  background: rgba(31, 41, 55, 0.95);
+  border-radius: var(--radius);
+  padding: 1.5rem;
+  border: 1px solid var(--border);
+  box-shadow: 0 10px 40px rgba(15, 23, 42, 0.45);
+}
+
+.event-details {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1rem 1.25rem;
+  margin: 0;
+}
+
+.event-details div {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.event-details dt {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.event-details dd {
+  margin: 0;
+  font-weight: 600;
+}
+
+.session-status {
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(34, 197, 94, 0.16);
+  color: #4ade80;
+  font-weight: 600;
+  border: 1px solid rgba(34, 197, 94, 0.35);
+}
+
+.session-status.closed {
+  background: rgba(248, 113, 113, 0.18);
+  color: #fca5a5;
+  border-color: rgba(248, 113, 113, 0.45);
+}
+
+.player-banner {
+  background: rgba(59, 130, 246, 0.12);
+  border: 1px solid rgba(59, 130, 246, 0.4);
+  border-radius: var(--radius);
+  padding: 1rem 1.25rem;
+  color: #bfdbfe;
+}
+
+.section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1.25rem;
+}
+
+.section-header h2 {
+  margin: 0;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  font-weight: 600;
+  color: var(--muted);
+}
+
+input[type="text"],
+input[type="number"],
+select {
+  border-radius: 8px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  padding: 0.55rem 0.75rem;
+  background: rgba(17, 24, 39, 0.7);
+  color: var(--text);
+  font-size: 1rem;
+  transition: border-color 0.2s ease, background 0.2s ease;
+}
+
+input[type="text"]:focus,
+input[type="number"]:focus,
+select:focus {
+  outline: none;
+  border-color: var(--accent);
+  background: rgba(17, 24, 39, 0.9);
+}
+
+.currency-input {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+}
+
+.currency-input .currency-symbol {
+  color: var(--muted);
+}
+
+select {
+  appearance: none;
+  background-image: linear-gradient(45deg, transparent 50%, var(--muted) 50%),
+    linear-gradient(135deg, var(--muted) 50%, transparent 50%);
+  background-position: calc(100% - 18px) calc(50% - 3px), calc(100% - 12px) calc(50% - 3px);
+  background-size: 6px 6px, 6px 6px;
+  background-repeat: no-repeat;
+  padding-right: 2.5rem;
+}
+
+button {
+  font: inherit;
+  border: none;
+  border-radius: 999px;
+  padding: 0.55rem 1.2rem;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.2s ease;
+}
+
+button.primary {
+  background: linear-gradient(135deg, var(--accent), var(--accent-dark));
+  color: white;
+  box-shadow: 0 10px 25px rgba(124, 58, 237, 0.35);
+}
+
+button.primary:hover,
+button.primary:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 30px rgba(124, 58, 237, 0.5);
+}
+
+button.ghost {
+  background: rgba(148, 163, 184, 0.08);
+  color: var(--text);
+  border: 1px solid rgba(148, 163, 184, 0.15);
+}
+
+button.ghost:hover,
+button.ghost:focus-visible {
+  background: rgba(148, 163, 184, 0.15);
+}
+
+.table-wrapper {
+  overflow-x: auto;
+}
+
+.settings-toggle {
+  position: fixed;
+  top: 1.5rem;
+  left: 1.5rem;
+  width: 46px;
+  height: 46px;
+  border-radius: 14px;
+  background: rgba(15, 23, 42, 0.85);
+  border: 1px solid rgba(148, 163, 184, 0.15);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 6px;
+  padding: 0.75rem;
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.4);
+  z-index: 20;
+}
+
+.settings-toggle span {
+  display: block;
+  height: 2px;
+  background: var(--text);
+  border-radius: 999px;
+}
+
+.settings-toggle.hidden {
+  display: none;
+}
+
+.settings-panel {
+  position: fixed;
+  inset: 0 auto 0 0;
+  width: min(320px, 85vw);
+  background: rgba(15, 23, 42, 0.96);
+  border-right: 1px solid rgba(148, 163, 184, 0.18);
+  box-shadow: 20px 0 40px rgba(15, 23, 42, 0.65);
+  transform: translateX(-100%);
+  transition: transform 0.3s ease;
+  padding: 1.5rem;
+  z-index: 30;
+  overflow-y: auto;
+}
+
+.settings-panel.open {
+  transform: translateX(0);
+}
+
+.settings-panel.player-hidden {
+  display: none;
+}
+
+.settings-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.settings-header h2 {
+  margin: 0;
+}
+
+.settings-body {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.settings-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.65);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.25s ease;
+  z-index: 25;
+}
+
+.settings-overlay.visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 600px;
+}
+
+thead {
+  background: rgba(15, 23, 42, 0.85);
+}
+
+th,
+td {
+  text-align: left;
+  padding: 0.75rem 0.9rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.15);
+}
+
+th {
+  font-weight: 600;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-size: 0.8rem;
+}
+
+tbody tr:hover {
+  background: rgba(79, 70, 229, 0.08);
+}
+
+.net-result.positive {
+  color: var(--success);
+}
+
+.net-result.negative,
+.outcome.negative {
+  color: var(--danger);
+}
+
+.outcome.positive {
+  color: var(--success);
+}
+
+#table-delta.alert {
+  color: #f87171;
+  background: rgba(248, 113, 113, 0.16);
+  padding: 0.3rem 0.6rem;
+  border-radius: 8px;
+  display: inline-block;
+}
+
+.summary-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.summary-card {
+  background: rgba(15, 23, 42, 0.6);
+  border-radius: 12px;
+  padding: 1rem 1.25rem;
+  border: 1px solid rgba(148, 163, 184, 0.1);
+}
+
+.summary-card h3 {
+  margin-top: 0;
+  font-size: 0.95rem;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.metric {
+  font-size: 1.7rem;
+  font-weight: 700;
+  margin: 0.2rem 0 0;
+}
+
+.hint {
+  margin: 0.2rem 0 0;
+  font-size: 0.75rem;
+  color: var(--muted);
+}
+
+button.disabled,
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+  box-shadow: none;
+}
+
+.actions {
+  width: 1%;
+  white-space: nowrap;
+}
+
+.actions .hidden {
+  display: none;
+}
+
+@media (max-width: 720px) {
+  body {
+    padding: 1rem;
+  }
+
+  table {
+    min-width: unset;
+  }
+
+  th,
+  td {
+    padding: 0.65rem;
+  }
+
+  .settings-toggle {
+    top: 1rem;
+    left: 1rem;
+  }
+}


### PR DESCRIPTION
## Summary
- implement a slide-out settings drawer so admins can manage host details, currency, reported totals, session status, and generate the player link
- add an event overview card, player registration banner, and enforce session open/close rules that lock editing and highlight non-zero table deltas
- refresh the README to document the configurable settings, player flow, and new safeguards

## Testing
- python -m http.server 8000


------
https://chatgpt.com/codex/tasks/task_e_68d919a15d948329829959c5b4a9d000