### PR TITLE
Switch to dependency-free server and seed demo data

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# Use an official Node.js runtime as a parent image
+FROM node:20-alpine
+
+# Create app directory
+WORKDIR /app
+
+# Install app dependencies
+COPY package*.json ./
+RUN npm install --production
+
+# Bundle app source
+COPY . .
+
+# Expose the port the app runs on
+EXPOSE 3000
+
+# Create volume mount point for persisted session data
+VOLUME ["/app/data"]
+
+# Run the application
+CMD ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -1,21 +1,45 @@
 # Poker Night Tracker
 
-A lightweight, client-side web app to coordinate poker nights end-to-end. Hosts can configure the session, invite players to register themselves, and keep tabs on table totals, expenses, and outcomes. All data stays in the browser via `localStorage` so every host can quickly resume where they left off.
+A full-stack poker night companion that lets hosts coordinate sessions, track cash movement, and review historical performance.
 
 ## Features
 
-- Slide-out settings menu with host controls for name, location, session date/time, preferred currency (USD, EUR, or ILS), reported final cash, and table expenses.
-- Session status management so the administrator can open or close editing. Player inputs are locked and the add/remove buttons are disabled the moment a night is closed.
-- Shareable player registration link (`?role=player`) that reveals a streamlined view where guests can add themselves and update their buy-ins/final cash while the session is open.
-- Live summary showing total buy-ins, final cash, table delta (highlighted bright red when off), leftover cash after expenses, and win/loss counts.
-- Data automatically persists in the same browser via `localStorage` with a one-click reset when you need to start fresh.
+- Slide-out settings drawer with host controls for name, location, date/time, preferred currency (USD, EUR, or ILS), reported totals, and table expenses.
+- Session lifecycle management: administrators can open/close a night, and once closed, player inputs are locked until a fresh session begins.
+- Shareable player registration mode (`?role=player`) so guests can enter their buy-ins and cash-out amounts while the event remains open.
+- Persistent session archive stored on disk (`data/sessions.json`) so every night is saved for future reference.
+- Historical scoreboard that surfaces the most profitable player and win leaders per session, by year, or across all time, complete with filterable tables.
+- Real-time summary metrics: total buy-ins, total cash out, table delta (highlighted bright red when not balanced), expense totals, and cumulative wins/losses.
 
 ## Getting started
 
-Open `index.html` in any modern browser, or serve the repo locally:
+No external dependencies are required—the server is built on Node's core modules. Populate the sample data, then launch the tracker:
 
 ```bash
-python -m http.server 8000
+npm run seed   # creates data/sessions.json with 3 sessions and 5 active players
+npm start
 ```
 
-Then navigate to http://localhost:8000.
+Then open http://localhost:3000 in your browser.
+
+Sessions and player data are written to `data/sessions.json`. Each update is saved automatically while a session is open, and closing a session locks it into the archive so you can compare past results from the scoreboard. Re-run `npm run seed` at any time to restore the demo data.
+
+## Running with Docker
+
+You can also run the tracker in a container using the provided `Dockerfile`.
+
+1. Build the image:
+
+   ```bash
+   docker build -t poker-night-tracker .
+   ```
+
+2. Launch the container and expose port 3000. Mount a local directory to persist session history between runs:
+
+   ```bash
+   docker run --rm -p 3000:3000 -v "$(pwd)/data:/app/data" poker-night-tracker
+   ```
+
+   On Windows PowerShell, use `${PWD}` instead of `$(pwd)` for the bind mount path.
+
+With the container running, browse to http://localhost:3000 to access the app. All session data remains in your mounted `data` directory so historical results survive container restarts.

--- a/README.md
+++ b/README.md
@@ -43,3 +43,7 @@ You can also run the tracker in a container using the provided `Dockerfile`.
    On Windows PowerShell, use `${PWD}` instead of `$(pwd)` for the bind mount path.
 
 With the container running, browse to http://localhost:3000 to access the app. All session data remains in your mounted `data` directory so historical results survive container restarts.
+
+## Branching
+
+All development now lives on the `main` branch. Previous working branches have been consolidated so you can pull directly from `main` to receive the latest tracker updates.

--- a/REBASE_NOTES.md
+++ b/REBASE_NOTES.md
@@ -1,0 +1,5 @@
+# Rebase Summary
+
+- The `texas-holdem-rebased` branch was created after rebasing the feature work onto `main` (commit `af39a88`).
+- All application files introduced by the Texas Hold'em overhaul remain intact on top of the refreshed history.
+- Use this branch for further development or to open a pull request targeting `main`.

--- a/data/.gitignore
+++ b/data/.gitignore
@@ -1,0 +1,1 @@
+sessions.json

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Poker Face Tracker</title>
+  <title>Texas Hold'em Tracker</title>
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
@@ -77,8 +77,8 @@
   <main class="app">
     <header>
       <div>
-        <h1>Poker Night Tracker</h1>
-        <p class="subtitle">Track registrations, final cash, buy-ins, and table results for poker night.</p>
+        <h1>Texas Hold'em Night Tracker</h1>
+        <p class="subtitle">Run the table with live chip counts, buy-ins, and final tallies for every Hold'em session.</p>
       </div>
       <div class="session-status" id="session-status-indicator">Session open</div>
     </header>
@@ -204,9 +204,22 @@
         </article>
       </div>
       <div class="scoreboard-summary" role="list">
-        <p id="scoreboard-summary-gain" role="listitem">Top earner: —</p>
-        <p id="scoreboard-summary-loss" role="listitem">Biggest loss: —</p>
-        <p id="scoreboard-summary-rank" role="listitem">Rank changes: —</p>
+        <article class="summary-brick" role="listitem">
+          <h3>Big Winner</h3>
+          <p id="scoreboard-winner-name" class="metric">—</p>
+          <p id="scoreboard-winner-value" class="detail">—</p>
+        </article>
+        <article class="summary-brick" role="listitem">
+          <h3>Tough Night</h3>
+          <p id="scoreboard-loser-name" class="metric">—</p>
+          <p id="scoreboard-loser-value" class="detail">—</p>
+        </article>
+        <article class="summary-brick" role="listitem">
+          <h3>Scoreboard Moves</h3>
+          <div id="scoreboard-moves" class="movement-list" role="list">
+            <p class="movement-empty">—</p>
+          </div>
+        </article>
       </div>
       <div class="table-wrapper">
         <table>

--- a/index.html
+++ b/index.html
@@ -203,6 +203,11 @@
           <p id="scoreboard-wins-value" class="hint">—</p>
         </article>
       </div>
+      <div class="scoreboard-summary" role="list">
+        <p id="scoreboard-summary-gain" role="listitem">Top earner: —</p>
+        <p id="scoreboard-summary-loss" role="listitem">Biggest loss: —</p>
+        <p id="scoreboard-summary-rank" role="listitem">Rank changes: —</p>
+      </div>
       <div class="table-wrapper">
         <table>
           <thead>

--- a/index.html
+++ b/index.html
@@ -65,7 +65,8 @@
       </section>
       <section aria-labelledby="admin-actions-heading">
         <h3 id="admin-actions-heading">Admin actions</h3>
-        <button id="reset-btn" class="ghost">Reset all data</button>
+        <button id="start-session-btn" class="primary">Start new session</button>
+        <button id="reset-btn" class="ghost">Clear current session</button>
         <p class="hint">Share this link so players can register: <span id="player-link"></span></p>
       </section>
     </div>
@@ -166,6 +167,61 @@
           <p id="wins-losses" class="metric">0 / 0</p>
         </article>
       </div>
+    </section>
+
+    <section class="card" aria-labelledby="scoreboard-heading">
+      <div class="section-header scoreboard-header">
+        <h2 id="scoreboard-heading">Scoreboard</h2>
+        <div class="scoreboard-filters">
+          <label>
+            Scope
+            <select id="scoreboard-scope">
+              <option value="session">Session</option>
+              <option value="year">Year</option>
+              <option value="all">All time</option>
+            </select>
+          </label>
+          <label id="scoreboard-session-wrapper">
+            Session
+            <select id="scoreboard-session"></select>
+          </label>
+          <label id="scoreboard-year-wrapper" hidden>
+            Year
+            <select id="scoreboard-year"></select>
+          </label>
+        </div>
+      </div>
+      <div class="scoreboard-leaders">
+        <article class="summary-card" role="listitem">
+          <h3>Top profit</h3>
+          <p id="scoreboard-profit-name" class="metric">—</p>
+          <p id="scoreboard-profit-value" class="hint">—</p>
+        </article>
+        <article class="summary-card" role="listitem">
+          <h3>Most wins</h3>
+          <p id="scoreboard-wins-name" class="metric">—</p>
+          <p id="scoreboard-wins-value" class="hint">—</p>
+        </article>
+      </div>
+      <div class="table-wrapper">
+        <table>
+          <thead>
+            <tr>
+              <th scope="col">Player</th>
+              <th scope="col">Sessions</th>
+              <th scope="col">Wins</th>
+              <th scope="col">Losses</th>
+              <th scope="col">Net</th>
+            </tr>
+          </thead>
+          <tbody id="scoreboard-table">
+            <tr>
+              <td colspan="5" class="empty">No results yet</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <p id="scoreboard-note" class="hint"></p>
     </section>
   </main>
 

--- a/main.js
+++ b/main.js
@@ -1,3 +1,6 @@
+const API_BASE = '/api';
+const SAVE_DEBOUNCE_MS = 500;
+
 const settingsToggle = document.querySelector('#settings-toggle');
 const settingsPanel = document.querySelector('#settings-panel');
 const settingsOverlay = document.querySelector('#settings-overlay');
@@ -10,6 +13,7 @@ const expenseInput = document.querySelector('#table-expense');
 const reportedFinalInput = document.querySelector('#reported-final');
 const currencySelect = document.querySelector('#currency-select');
 const sessionStatusSelect = document.querySelector('#session-status');
+const startSessionBtn = document.querySelector('#start-session-btn');
 
 const addPlayerBtn = document.querySelector('#add-player-btn');
 const playersBody = document.querySelector('#players-body');
@@ -31,7 +35,18 @@ const displayDatetimeEl = document.querySelector('#display-datetime');
 const displayReportedFinalEl = document.querySelector('#display-reported-final');
 const displayExpensesEl = document.querySelector('#display-expenses');
 
-const STORAGE_KEY = 'poker-night-tracker';
+const scoreboardScopeSelect = document.querySelector('#scoreboard-scope');
+const scoreboardSessionWrapper = document.querySelector('#scoreboard-session-wrapper');
+const scoreboardYearWrapper = document.querySelector('#scoreboard-year-wrapper');
+const scoreboardSessionSelect = document.querySelector('#scoreboard-session');
+const scoreboardYearSelect = document.querySelector('#scoreboard-year');
+const scoreboardProfitName = document.querySelector('#scoreboard-profit-name');
+const scoreboardProfitValue = document.querySelector('#scoreboard-profit-value');
+const scoreboardWinsName = document.querySelector('#scoreboard-wins-name');
+const scoreboardWinsValue = document.querySelector('#scoreboard-wins-value');
+const scoreboardTableBody = document.querySelector('#scoreboard-table');
+const scoreboardNote = document.querySelector('#scoreboard-note');
+
 const CURRENCY_SYMBOLS = {
   USD: '$',
   EUR: '€',
@@ -41,16 +56,25 @@ const CURRENCY_SYMBOLS = {
 const searchParams = new URLSearchParams(window.location.search);
 const isPlayerView = searchParams.get('role') === 'player';
 
-function getCurrencySymbol() {
-  return CURRENCY_SYMBOLS[currencySelect.value] ?? '$';
+let sessions = [];
+let currentSession = null;
+let isRestoring = false;
+let saveTimeoutId = null;
+
+function sanitizeCurrency(code) {
+  return code && code in CURRENCY_SYMBOLS ? code : 'USD';
 }
 
-function formatCurrency(value) {
+function getCurrencySymbol(code = currencySelect?.value) {
+  return CURRENCY_SYMBOLS[sanitizeCurrency(code)] ?? '$';
+}
+
+function formatCurrency(value, currencyCode = currencySelect?.value) {
   const number = Number(value) || 0;
-  const currency = currencySelect.value in CURRENCY_SYMBOLS ? currencySelect.value : 'USD';
+  const code = sanitizeCurrency(currencyCode);
   return new Intl.NumberFormat(undefined, {
     style: 'currency',
-    currency,
+    currency: code,
     minimumFractionDigits: 2,
     maximumFractionDigits: 2,
   }).format(number);
@@ -66,7 +90,7 @@ function getPlayersData() {
     const buyins = Number(row.querySelector('.player-buyins').value) || 0;
     const final = Number(row.querySelector('.player-final').value) || 0;
     return {
-      id: row.dataset.id,
+      id: row.dataset.id || generateId(),
       name,
       buyins,
       final,
@@ -74,57 +98,91 @@ function getPlayersData() {
   });
 }
 
-function persistState() {
-  const state = {
+function collectCurrentSessionData() {
+  return {
+    id: currentSession?.id,
     settings: {
       hostName: hostNameInput.value,
       location: locationInput.value,
       datetime: datetimeInput.value,
       expenses: expenseInput.value,
       reportedFinal: reportedFinalInput.value,
-      currency: currencySelect.value,
-      sessionStatus: sessionStatusSelect.value,
+      currency: sanitizeCurrency(currencySelect.value),
+      sessionStatus: sessionStatusSelect.value === 'closed' ? 'closed' : 'open',
     },
     players: getPlayersData(),
   };
-
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
 }
 
-function restoreState() {
-  const stored = localStorage.getItem(STORAGE_KEY);
-  if (!stored) return;
+function mergeCurrentSessionDraft() {
+  if (!currentSession) return;
+  const draft = collectCurrentSessionData();
+  currentSession = {
+    ...currentSession,
+    ...draft,
+    settings: {
+      ...currentSession.settings,
+      ...draft.settings,
+    },
+    players: draft.players,
+  };
+  const index = sessions.findIndex((session) => session.id === currentSession.id);
+  if (index !== -1) {
+    sessions[index] = currentSession;
+  } else {
+    sessions.push(currentSession);
+  }
+}
+
+async function saveSessionNow() {
+  if (!currentSession) return;
+  mergeCurrentSessionDraft();
+  refreshScoreboardFilters();
+  updateScoreboard();
 
   try {
-    const state = JSON.parse(stored);
-    const settings = state.settings ?? {};
-
-    hostNameInput.value = settings.hostName ?? '';
-    locationInput.value = settings.location ?? '';
-    datetimeInput.value = settings.datetime ?? '';
-    expenseInput.value = settings.expenses ?? '';
-    reportedFinalInput.value = settings.reportedFinal ?? '';
-
-    if (settings.currency && settings.currency in CURRENCY_SYMBOLS) {
-      currencySelect.value = settings.currency;
-    } else {
-      currencySelect.value = 'USD';
-    }
-
-    if (settings.sessionStatus === 'closed') {
-      sessionStatusSelect.value = 'closed';
-    } else {
-      sessionStatusSelect.value = 'open';
-    }
-
-    playersBody.innerHTML = '';
-    (state.players ?? []).forEach((player) => {
-      const row = createPlayerRow(player);
-      playersBody.appendChild(row);
+    const response = await fetch(`${API_BASE}/sessions/${currentSession.id}`, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(currentSession),
     });
+
+    if (!response.ok) {
+      throw new Error(`Failed to save session: ${response.status}`);
+    }
+
+    const updated = await response.json();
+    currentSession = updated;
+    const index = sessions.findIndex((session) => session.id === updated.id);
+    if (index !== -1) {
+      sessions[index] = updated;
+    } else {
+      sessions.push(updated);
+    }
+    refreshScoreboardFilters();
+    updateScoreboard();
   } catch (error) {
-    console.error('Failed to restore tracker state', error);
+    console.error(error);
   }
+}
+
+function scheduleSave(immediate = false) {
+  if (isRestoring || !currentSession) {
+    return;
+  }
+  if (saveTimeoutId) {
+    clearTimeout(saveTimeoutId);
+  }
+  if (immediate) {
+    saveSessionNow();
+    return;
+  }
+  saveTimeoutId = setTimeout(() => {
+    saveTimeoutId = null;
+    saveSessionNow();
+  }, SAVE_DEBOUNCE_MS);
 }
 
 function updateEventDetails() {
@@ -147,36 +205,6 @@ function updateEventDetails() {
 
   displayReportedFinalEl.textContent = formatCurrency(reportedFinalInput.value);
   displayExpensesEl.textContent = formatCurrency(expenseInput.value);
-}
-
-function updateSessionStatusUI() {
-  const isClosed = sessionStatusSelect.value === 'closed';
-  if (sessionStatusIndicator) {
-    sessionStatusIndicator.textContent = isClosed ? 'Session closed' : 'Session open';
-    sessionStatusIndicator.classList.toggle('closed', isClosed);
-  }
-
-  const disablePlayerInputs = isClosed;
-  playersBody.querySelectorAll('input').forEach((input) => {
-    input.disabled = disablePlayerInputs;
-  });
-  playersBody.querySelectorAll('.remove-player').forEach((button) => {
-    button.disabled = disablePlayerInputs;
-    button.classList.toggle('disabled', disablePlayerInputs);
-  });
-
-  if (addPlayerBtn) {
-    addPlayerBtn.disabled = isClosed;
-    addPlayerBtn.classList.toggle('disabled', isClosed);
-  }
-}
-
-function updateCurrencySymbols() {
-  const symbol = getCurrencySymbol();
-  document.querySelectorAll('.currency-symbol').forEach((span) => {
-    span.textContent = symbol;
-  });
-  updateEventDetails();
 }
 
 function updateSummary() {
@@ -205,11 +233,6 @@ function updatePlayerLink() {
   playerLinkSpan.innerHTML = `<a href="${url.toString()}" target="_blank" rel="noopener">${url.toString()}</a>`;
 }
 
-function attachInputListeners(element, handler) {
-  element.addEventListener('input', handler);
-  element.addEventListener('change', handler);
-}
-
 function handlePlayerInputChange(row) {
   const buyinsInput = row.querySelector('.player-buyins');
   const finalInput = row.querySelector('.player-final');
@@ -225,11 +248,11 @@ function handlePlayerInputChange(row) {
   netCell.classList.remove('positive', 'negative');
   outcomeCell.classList.remove('positive', 'negative');
 
-  if (net > 0) {
+  if (net > 0.0001) {
     netCell.classList.add('positive');
     outcomeCell.textContent = 'Win';
     outcomeCell.classList.add('positive');
-  } else if (net < 0) {
+  } else if (net < -0.0001) {
     netCell.classList.add('negative');
     outcomeCell.textContent = 'Loss';
     outcomeCell.classList.add('negative');
@@ -239,8 +262,10 @@ function handlePlayerInputChange(row) {
     outcomeCell.textContent = '–';
   }
 
-  persistState();
   updateSummary();
+  if (!isRestoring) {
+    scheduleSave();
+  }
 }
 
 function createPlayerRow(player = {}) {
@@ -271,8 +296,8 @@ function createPlayerRow(player = {}) {
   removeBtn.addEventListener('click', () => {
     if (isPlayerView) return;
     row.remove();
-    persistState();
     updateSummary();
+    scheduleSave(true);
   });
 
   if (isPlayerView) {
@@ -284,39 +309,46 @@ function createPlayerRow(player = {}) {
   return row;
 }
 
+function addPlayerRow(player = {}) {
+  const row = createPlayerRow(player);
+  playersBody.appendChild(row);
+  return row;
+}
+
 function refreshAllRows() {
   playersBody.querySelectorAll('tr').forEach((row) => {
     handlePlayerInputChange(row);
   });
 }
 
-function resetAll() {
-  const confirmation = confirm('Reset host info and remove all players?');
-  if (!confirmation) {
-    return;
+function updateSessionStatusUI() {
+  const isClosed = sessionStatusSelect.value === 'closed';
+  if (sessionStatusIndicator) {
+    sessionStatusIndicator.textContent = isClosed ? 'Session closed' : 'Session open';
+    sessionStatusIndicator.classList.toggle('closed', isClosed);
   }
 
-  hostNameInput.value = '';
-  locationInput.value = '';
-  datetimeInput.value = '';
-  expenseInput.value = '';
-  reportedFinalInput.value = '';
-  currencySelect.value = 'USD';
-  sessionStatusSelect.value = 'open';
+  playersBody.querySelectorAll('input').forEach((input) => {
+    input.disabled = isClosed;
+  });
+  playersBody.querySelectorAll('.remove-player').forEach((button) => {
+    button.disabled = isClosed;
+    button.classList.toggle('disabled', isClosed);
+  });
 
-  playersBody.innerHTML = '';
-  addPlayerRow();
-  persistState();
-  updateCurrencySymbols();
-  updateSummary();
-  updateEventDetails();
-  updateSessionStatusUI();
+  if (addPlayerBtn) {
+    addPlayerBtn.disabled = isClosed;
+    addPlayerBtn.classList.toggle('disabled', isClosed);
+  }
 }
 
-function addPlayerRow(player = {}) {
-  const row = createPlayerRow(player);
-  playersBody.appendChild(row);
-  return row;
+function updateCurrencySymbols() {
+  const symbol = getCurrencySymbol();
+  document.querySelectorAll('.currency-symbol').forEach((span) => {
+    span.textContent = symbol;
+  });
+  updateEventDetails();
+  refreshAllRows();
 }
 
 function setupSettingsPanel() {
@@ -363,54 +395,426 @@ function updateViewForRole() {
       resetBtn.disabled = true;
       resetBtn.classList.add('disabled');
     }
+    if (startSessionBtn) {
+      startSessionBtn.disabled = true;
+      startSessionBtn.classList.add('disabled');
+    }
   }
 }
 
-function init() {
-  restoreState();
+function resetCurrentSession() {
+  if (!currentSession || isPlayerView) return;
+  const confirmation = confirm('Clear host info and remove all players from this session?');
+  if (!confirmation) {
+    return;
+  }
 
-  if (playersBody.children.length === 0) {
+  isRestoring = true;
+  hostNameInput.value = '';
+  locationInput.value = '';
+  datetimeInput.value = '';
+  expenseInput.value = '';
+  reportedFinalInput.value = '';
+  currencySelect.value = 'USD';
+  sessionStatusSelect.value = 'open';
+  playersBody.innerHTML = '';
+  addPlayerRow();
+  isRestoring = false;
+
+  updateCurrencySymbols();
+  updateEventDetails();
+  updateSummary();
+  updateSessionStatusUI();
+  scheduleSave(true);
+}
+
+async function createSessionOnServer() {
+  const response = await fetch(`${API_BASE}/sessions`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({}),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to create session: ${response.status}`);
+  }
+
+  return response.json();
+}
+
+async function startNewSession() {
+  if (!startSessionBtn || isPlayerView) return;
+  if (currentSession && currentSession.settings?.sessionStatus !== 'closed') {
+    alert('Close the current session before starting a new one.');
+    return;
+  }
+
+  try {
+    const session = await createSessionOnServer();
+    sessions.push(session);
+    currentSession = session;
+    populateSession(session);
+    refreshScoreboardFilters();
+    updateScoreboard();
+  } catch (error) {
+    console.error(error);
+  }
+}
+
+function getSessionDate(session) {
+  const value = session?.settings?.datetime || session?.createdAt;
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.valueOf())) return null;
+  return date;
+}
+
+function formatSessionLabel(session) {
+  const date = getSessionDate(session);
+  const host = session?.settings?.hostName?.trim();
+  const dateLabel = date
+    ? new Intl.DateTimeFormat(undefined, { dateStyle: 'medium', timeStyle: 'short' }).format(date)
+    : 'No date';
+  return host ? `${dateLabel} · ${host}` : dateLabel;
+}
+
+function getSessionYear(session) {
+  const date = getSessionDate(session);
+  if (!date) return 'Unknown';
+  return String(date.getFullYear());
+}
+
+function refreshScoreboardFilters() {
+  if (!scoreboardScopeSelect) return;
+
+  const previousSession = scoreboardSessionSelect?.value;
+  const previousYear = scoreboardYearSelect?.value;
+
+  if (scoreboardSessionSelect) {
+    scoreboardSessionSelect.innerHTML = '';
+    const sortedSessions = [...sessions].sort((a, b) => {
+      const dateA = getSessionDate(a)?.getTime() ?? 0;
+      const dateB = getSessionDate(b)?.getTime() ?? 0;
+      return dateB - dateA;
+    });
+
+    sortedSessions.forEach((session) => {
+      const option = document.createElement('option');
+      option.value = session.id;
+      option.textContent = formatSessionLabel(session);
+      scoreboardSessionSelect.appendChild(option);
+    });
+
+    if (previousSession && Array.from(scoreboardSessionSelect.options).some((opt) => opt.value === previousSession)) {
+      scoreboardSessionSelect.value = previousSession;
+    } else if (scoreboardSessionSelect.options.length > 0) {
+      scoreboardSessionSelect.value = scoreboardSessionSelect.options[0].value;
+    }
+    scoreboardSessionSelect.disabled = scoreboardSessionSelect.options.length === 0;
+  }
+
+  if (scoreboardYearSelect) {
+    scoreboardYearSelect.innerHTML = '';
+    const years = new Set();
+    sessions.forEach((session) => {
+      years.add(getSessionYear(session));
+    });
+    const sortedYears = Array.from(years).sort((a, b) => {
+      if (a === 'Unknown') return 1;
+      if (b === 'Unknown') return -1;
+      return Number(b) - Number(a);
+    });
+    sortedYears.forEach((year) => {
+      const option = document.createElement('option');
+      option.value = year;
+      option.textContent = year;
+      scoreboardYearSelect.appendChild(option);
+    });
+
+    if (previousYear && Array.from(scoreboardYearSelect.options).some((opt) => opt.value === previousYear)) {
+      scoreboardYearSelect.value = previousYear;
+    } else if (scoreboardYearSelect.options.length > 0) {
+      scoreboardYearSelect.value = scoreboardYearSelect.options[0].value;
+    }
+    scoreboardYearSelect.disabled = scoreboardYearSelect.options.length === 0;
+  }
+
+  handleScoreboardScopeChange();
+}
+
+function handleScoreboardScopeChange() {
+  if (!scoreboardScopeSelect) return;
+  const scope = scoreboardScopeSelect.value;
+  if (scoreboardSessionWrapper) {
+    scoreboardSessionWrapper.hidden = scope !== 'session';
+  }
+  if (scoreboardYearWrapper) {
+    scoreboardYearWrapper.hidden = scope !== 'year';
+  }
+  updateScoreboard();
+}
+
+function determineCurrencyForSessions(selectedSessions) {
+  const currencies = new Set();
+  selectedSessions.forEach((session) => {
+    const code = sanitizeCurrency(session?.settings?.currency);
+    currencies.add(code);
+  });
+  if (currencies.size === 1) {
+    return currencies.values().next().value;
+  }
+  return null;
+}
+
+function computePlayerStats(selectedSessions) {
+  const stats = new Map();
+
+  selectedSessions.forEach((session) => {
+    const sessionId = session.id;
+    (session.players ?? []).forEach((player) => {
+      const name = player.name?.trim() || 'Unnamed player';
+      const buyins = Number(player.buyins) || 0;
+      const final = Number(player.final) || 0;
+      const net = final - buyins;
+      const entry = stats.get(name) || {
+        name,
+        totalBuyins: 0,
+        totalFinal: 0,
+        totalNet: 0,
+        wins: 0,
+        losses: 0,
+        sessions: new Set(),
+      };
+
+      entry.totalBuyins += buyins;
+      entry.totalFinal += final;
+      entry.totalNet += net;
+      entry.sessions.add(sessionId);
+      if (net > 0.0001) {
+        entry.wins += 1;
+      } else if (net < -0.0001) {
+        entry.losses += 1;
+      }
+      stats.set(name, entry);
+    });
+  });
+
+  return Array.from(stats.values()).map((entry) => ({
+    ...entry,
+    sessionsPlayed: entry.sessions.size,
+  }));
+}
+
+function updateScoreboard() {
+  if (!scoreboardTableBody || !scoreboardScopeSelect) return;
+
+  const scope = scoreboardScopeSelect.value;
+  let selectedSessions = [];
+  let contextLabel = '';
+
+  if (scope === 'session') {
+    const sessionId = scoreboardSessionSelect?.value;
+    if (sessionId) {
+      const session = sessions.find((item) => item.id === sessionId);
+      if (session) {
+        selectedSessions = [session];
+        contextLabel = formatSessionLabel(session);
+      }
+    }
+  } else if (scope === 'year') {
+    const year = scoreboardYearSelect?.value;
+    if (year) {
+      selectedSessions = sessions.filter((session) => getSessionYear(session) === year);
+      contextLabel = year === 'Unknown' ? 'Sessions without a set date' : `Year ${year}`;
+    }
+  } else {
+    selectedSessions = [...sessions];
+    contextLabel = 'All sessions';
+  }
+
+  if (selectedSessions.length === 0) {
+    scoreboardTableBody.innerHTML = '<tr><td colspan="5" class="empty">No results yet</td></tr>';
+    scoreboardProfitName.textContent = '—';
+    scoreboardProfitValue.textContent = '—';
+    scoreboardWinsName.textContent = '—';
+    scoreboardWinsValue.textContent = '—';
+    scoreboardNote.textContent = sessions.length === 0 ? 'No sessions recorded yet.' : 'No sessions available for the selected view.';
+    return;
+  }
+
+  const playerStats = computePlayerStats(selectedSessions);
+  if (playerStats.length === 0) {
+    scoreboardTableBody.innerHTML = '<tr><td colspan="5" class="empty">No player results yet</td></tr>';
+    scoreboardProfitName.textContent = '—';
+    scoreboardProfitValue.textContent = '—';
+    scoreboardWinsName.textContent = '—';
+    scoreboardWinsValue.textContent = '—';
+    scoreboardNote.textContent = `${contextLabel || 'Selected view'} has no player data yet.`;
+    return;
+  }
+
+  playerStats.sort((a, b) => {
+    if (b.totalNet !== a.totalNet) {
+      return b.totalNet - a.totalNet;
+    }
+    return a.name.localeCompare(b.name);
+  });
+
+  const currencyForScope = determineCurrencyForSessions(selectedSessions);
+
+  const profitLeader = playerStats[0];
+  scoreboardProfitName.textContent = profitLeader.name;
+  scoreboardProfitValue.textContent = currencyForScope
+    ? formatCurrency(profitLeader.totalNet, currencyForScope)
+    : `${profitLeader.totalNet.toFixed(2)} (mixed)`;
+
+  const winLeader = playerStats.reduce((best, candidate) => {
+    if (!best) return candidate;
+    if (candidate.wins > best.wins) return candidate;
+    if (candidate.wins === best.wins) {
+      if (candidate.totalNet > best.totalNet) return candidate;
+      if (candidate.totalNet === best.totalNet) {
+        return candidate.name.localeCompare(best.name) < 0 ? candidate : best;
+      }
+    }
+    return best;
+  }, null);
+
+  if (winLeader) {
+    scoreboardWinsName.textContent = winLeader.name;
+    scoreboardWinsValue.textContent = `${winLeader.wins} win${winLeader.wins === 1 ? '' : 's'}`;
+  } else {
+    scoreboardWinsName.textContent = '—';
+    scoreboardWinsValue.textContent = '—';
+  }
+
+  scoreboardTableBody.innerHTML = '';
+  playerStats.forEach((entry) => {
+    const row = document.createElement('tr');
+    const values = [
+      entry.name,
+      String(entry.sessionsPlayed),
+      String(entry.wins),
+      String(entry.losses),
+      currencyForScope ? formatCurrency(entry.totalNet, currencyForScope) : `${entry.totalNet.toFixed(2)} (mixed)`,
+    ];
+
+    values.forEach((value) => {
+      const cell = document.createElement('td');
+      cell.textContent = value;
+      row.appendChild(cell);
+    });
+
+    scoreboardTableBody.appendChild(row);
+  });
+
+  const totalSessions = selectedSessions.length;
+  const sessionWord = totalSessions === 1 ? 'session' : 'sessions';
+  const currencyNote = currencyForScope
+    ? `Values shown in ${currencyForScope}.`
+    : 'Results span multiple currencies.';
+  scoreboardNote.textContent = `${contextLabel || 'Selected view'} · ${totalSessions} ${sessionWord}. ${currencyNote}`;
+}
+
+function populateSession(session) {
+  if (!session) return;
+  isRestoring = true;
+
+  const settings = session.settings ?? {};
+  hostNameInput.value = settings.hostName ?? '';
+  locationInput.value = settings.location ?? '';
+  datetimeInput.value = settings.datetime ?? '';
+  expenseInput.value = settings.expenses ?? '';
+  reportedFinalInput.value = settings.reportedFinal ?? '';
+  currencySelect.value = sanitizeCurrency(settings.currency);
+  sessionStatusSelect.value = settings.sessionStatus === 'closed' ? 'closed' : 'open';
+
+  playersBody.innerHTML = '';
+  if (Array.isArray(session.players) && session.players.length > 0) {
+    session.players.forEach((player) => addPlayerRow(player));
+  } else {
     addPlayerRow();
   }
 
-  updateViewForRole();
-  setupSettingsPanel();
   updateCurrencySymbols();
   updateEventDetails();
   updateSummary();
   updateSessionStatusUI();
   updatePlayerLink();
 
+  isRestoring = false;
+}
+
+async function loadSessions() {
+  try {
+    const response = await fetch(`${API_BASE}/sessions`);
+    if (!response.ok) {
+      throw new Error(`Failed to load sessions: ${response.status}`);
+    }
+    const data = await response.json();
+    sessions = Array.isArray(data.sessions) ? data.sessions : [];
+
+    currentSession = sessions.find((session) => session.settings?.sessionStatus === 'open');
+    if (!currentSession) {
+      sessions.sort((a, b) => {
+        const dateA = getSessionDate(a)?.getTime() ?? 0;
+        const dateB = getSessionDate(b)?.getTime() ?? 0;
+        return dateB - dateA;
+      });
+      currentSession = sessions[0] ?? null;
+    }
+
+    if (!currentSession) {
+      currentSession = await createSessionOnServer();
+      sessions.push(currentSession);
+    }
+
+    populateSession(currentSession);
+    refreshScoreboardFilters();
+    updateScoreboard();
+  } catch (error) {
+    console.error(error);
+  }
+}
+
+function attachInputListeners(element, handler) {
+  if (!element) return;
+  element.addEventListener('input', handler);
+  element.addEventListener('change', handler);
+}
+
+function initEventListeners() {
   attachInputListeners(hostNameInput, () => {
     updateEventDetails();
-    persistState();
+    scheduleSave();
   });
   attachInputListeners(locationInput, () => {
     updateEventDetails();
-    persistState();
+    scheduleSave();
   });
   attachInputListeners(datetimeInput, () => {
     updateEventDetails();
-    persistState();
+    scheduleSave();
+    refreshScoreboardFilters();
   });
   attachInputListeners(expenseInput, () => {
     updateEventDetails();
-    persistState();
     updateSummary();
+    scheduleSave();
   });
   attachInputListeners(reportedFinalInput, () => {
     updateEventDetails();
-    persistState();
+    scheduleSave();
   });
   attachInputListeners(currencySelect, () => {
     updateCurrencySymbols();
-    refreshAllRows();
-    persistState();
-    updateSummary();
+    scheduleSave();
   });
   attachInputListeners(sessionStatusSelect, () => {
     updateSessionStatusUI();
-    persistState();
+    scheduleSave(true);
   });
 
   addPlayerBtn?.addEventListener('click', () => {
@@ -420,11 +824,22 @@ function init() {
       return;
     }
     row.querySelector('.player-name')?.focus();
-    persistState();
-    updateSummary();
+    scheduleSave();
   });
 
-  resetBtn?.addEventListener('click', resetAll);
+  resetBtn?.addEventListener('click', resetCurrentSession);
+  startSessionBtn?.addEventListener('click', startNewSession);
+
+  scoreboardScopeSelect?.addEventListener('change', handleScoreboardScopeChange);
+  scoreboardSessionSelect?.addEventListener('change', updateScoreboard);
+  scoreboardYearSelect?.addEventListener('change', updateScoreboard);
+}
+
+async function init() {
+  updateViewForRole();
+  setupSettingsPanel();
+  await loadSessions();
+  initEventListeners();
 }
 
 window.addEventListener('DOMContentLoaded', init);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "pokerface-tracker",
+  "version": "1.1.0",
+  "description": "Poker night tracker with session history",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "seed": "node scripts/seedSessions.js"
+  }
+}

--- a/scripts/seedSessions.js
+++ b/scripts/seedSessions.js
@@ -1,0 +1,116 @@
+const fs = require('fs').promises;
+const path = require('path');
+
+const DATA_DIR = path.join(__dirname, '..', 'data');
+const SESSIONS_FILE = path.join(DATA_DIR, 'sessions.json');
+
+function makePlayer(id, name, buyins, final) {
+  return {
+    id,
+    name,
+    buyins,
+    final,
+  };
+}
+
+function sessionTemplate({
+  id,
+  createdAt,
+  updatedAt,
+  hostName,
+  location,
+  datetime,
+  expenses,
+  reportedFinal,
+  currency,
+  status,
+  players,
+}) {
+  return {
+    id,
+    createdAt,
+    updatedAt,
+    settings: {
+      hostName,
+      location,
+      datetime,
+      expenses,
+      reportedFinal,
+      currency,
+      sessionStatus: status,
+    },
+    players,
+  };
+}
+
+async function seed() {
+  await fs.mkdir(DATA_DIR, { recursive: true });
+
+  const now = new Date();
+  const isoNow = now.toISOString();
+  const sessions = [
+    sessionTemplate({
+      id: 'session-2025-main',
+      createdAt: isoNow,
+      updatedAt: isoNow,
+      hostName: 'Jamie Rivera',
+      location: 'Skyline Loft',
+      datetime: new Date(now.getFullYear(), now.getMonth(), now.getDate(), 20, 0, 0).toISOString(),
+      expenses: 150,
+      reportedFinal: 2800,
+      currency: 'USD',
+      status: 'open',
+      players: [
+        makePlayer('player-alex', 'Alex Morgan', 400, 525),
+        makePlayer('player-bree', 'Bree Chen', 300, 180),
+        makePlayer('player-cam', 'Cam Patel', 250, 420),
+        makePlayer('player-dev', 'Devon Price', 500, 760),
+        makePlayer('player-eden', 'Eden Solis', 350, 290),
+      ],
+    }),
+    sessionTemplate({
+      id: 'session-2024-holiday',
+      createdAt: '2024-12-20T02:15:00.000Z',
+      updatedAt: '2024-12-20T06:15:00.000Z',
+      hostName: 'Jamie Rivera',
+      location: 'Mountain Retreat',
+      datetime: '2024-12-19T20:30:00.000Z',
+      expenses: 120,
+      reportedFinal: 2400,
+      currency: 'EUR',
+      status: 'closed',
+      players: [
+        makePlayer('player-alex-2024', 'Alex Morgan', 450, 610),
+        makePlayer('player-bree-2024', 'Bree Chen', 300, 250),
+        makePlayer('player-fern-2024', 'Fernando Ortiz', 280, 360),
+        makePlayer('player-ida-2024', 'Ida Novak', 320, 260),
+      ],
+    }),
+    sessionTemplate({
+      id: 'session-2023-spring',
+      createdAt: '2023-04-10T01:00:00.000Z',
+      updatedAt: '2023-04-10T04:45:00.000Z',
+      hostName: 'Jamie Rivera',
+      location: 'Riverfront Condo',
+      datetime: '2023-04-09T19:45:00.000Z',
+      expenses: 95,
+      reportedFinal: 2100,
+      currency: 'USD',
+      status: 'closed',
+      players: [
+        makePlayer('player-cam-2023', 'Cam Patel', 260, 480),
+        makePlayer('player-dev-2023', 'Devon Price', 420, 340),
+        makePlayer('player-fern-2023', 'Fernando Ortiz', 200, 260),
+        makePlayer('player-gia-2023', 'Gia Walters', 280, 320),
+      ],
+    }),
+  ];
+
+  await fs.writeFile(SESSIONS_FILE, JSON.stringify(sessions, null, 2));
+  console.log(`Seeded ${sessions.length} sessions with ${sessions[0].players.length} active players.`);
+}
+
+seed().catch((error) => {
+  console.error('Failed to seed sessions file:', error);
+  process.exitCode = 1;
+});

--- a/server.js
+++ b/server.js
@@ -1,0 +1,229 @@
+const http = require('http');
+const fs = require('fs');
+const fsp = require('fs').promises;
+const path = require('path');
+const { URL } = require('url');
+
+const PORT = process.env.PORT || 3000;
+const ROOT_DIR = __dirname;
+const DATA_DIR = path.join(ROOT_DIR, 'data');
+const SESSIONS_FILE = path.join(DATA_DIR, 'sessions.json');
+
+const MIME_TYPES = {
+  '.html': 'text/html; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.js': 'application/javascript; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.ico': 'image/x-icon',
+};
+
+async function ensureDataFile() {
+  try {
+    await fsp.mkdir(DATA_DIR, { recursive: true });
+    await fsp.access(SESSIONS_FILE);
+  } catch (error) {
+    await fsp.writeFile(SESSIONS_FILE, JSON.stringify([], null, 2));
+  }
+}
+
+async function readSessions() {
+  await ensureDataFile();
+  const raw = await fsp.readFile(SESSIONS_FILE, 'utf-8');
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch (error) {
+    console.error('Failed to parse sessions file. Resetting to empty array.', error);
+    await fsp.writeFile(SESSIONS_FILE, JSON.stringify([], null, 2));
+    return [];
+  }
+}
+
+async function writeSessions(sessions) {
+  await ensureDataFile();
+  await fsp.writeFile(SESSIONS_FILE, JSON.stringify(sessions, null, 2));
+}
+
+function generateId() {
+  return `session-${Math.random().toString(36).slice(2)}-${Date.now()}`;
+}
+
+function sendJson(res, statusCode, payload) {
+  const body = JSON.stringify(payload);
+  res.writeHead(statusCode, {
+    'Content-Type': 'application/json; charset=utf-8',
+    'Cache-Control': 'no-store',
+  });
+  res.end(body);
+}
+
+async function parseRequestBody(req) {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    req.setEncoding('utf8');
+    req.on('data', (chunk) => {
+      data += chunk;
+      if (data.length > 1_000_000) {
+        reject(new Error('Payload too large'));
+        req.destroy();
+      }
+    });
+    req.on('end', () => {
+      if (!data) {
+        resolve({});
+        return;
+      }
+      try {
+        resolve(JSON.parse(data));
+      } catch (error) {
+        reject(error);
+      }
+    });
+    req.on('error', reject);
+  });
+}
+
+function serveStaticFile(res, filePath) {
+  fs.stat(filePath, (statError, stats) => {
+    if (statError || !stats.isFile()) {
+      res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
+      res.end('Not found');
+      return;
+    }
+
+    const ext = path.extname(filePath).toLowerCase();
+    const contentType = MIME_TYPES[ext] || 'application/octet-stream';
+    res.writeHead(200, {
+      'Content-Type': contentType,
+      'Cache-Control': ext === '.html' ? 'no-cache' : 'public, max-age=3600',
+    });
+    fs.createReadStream(filePath).pipe(res);
+  });
+}
+
+function isApiRoute(urlPath) {
+  return urlPath.startsWith('/api/');
+}
+
+async function handleApiRequest(req, res, url) {
+  const { pathname } = url;
+
+  if (req.method === 'GET' && pathname === '/api/sessions') {
+    const sessions = await readSessions();
+    sendJson(res, 200, { sessions });
+    return;
+  }
+
+  if (req.method === 'POST' && pathname === '/api/sessions') {
+    try {
+      const payload = await parseRequestBody(req);
+      const sessions = await readSessions();
+      const timestamp = new Date().toISOString();
+      const session = {
+        id: payload.id || generateId(),
+        createdAt: timestamp,
+        updatedAt: timestamp,
+        settings: {
+          hostName: '',
+          location: '',
+          datetime: '',
+          expenses: '',
+          reportedFinal: '',
+          currency: 'USD',
+          sessionStatus: 'open',
+          ...(payload.settings || {}),
+        },
+        players: Array.isArray(payload.players) ? payload.players : [],
+      };
+      sessions.push(session);
+      await writeSessions(sessions);
+      sendJson(res, 201, session);
+    } catch (error) {
+      console.error('Failed to create session', error);
+      sendJson(res, 400, { message: 'Invalid JSON payload' });
+    }
+    return;
+  }
+
+  const match = pathname.match(/^\/api\/sessions\/([^/]+)$/);
+  if (match) {
+    const sessionId = decodeURIComponent(match[1]);
+    const sessions = await readSessions();
+    const index = sessions.findIndex((item) => item.id === sessionId);
+
+    if (req.method === 'GET') {
+      if (index === -1) {
+        sendJson(res, 404, { message: 'Session not found' });
+        return;
+      }
+      sendJson(res, 200, sessions[index]);
+      return;
+    }
+
+    if (req.method === 'PUT') {
+      if (index === -1) {
+        sendJson(res, 404, { message: 'Session not found' });
+        return;
+      }
+
+      try {
+        const payload = await parseRequestBody(req);
+        const existing = sessions[index];
+        const updated = {
+          ...existing,
+          ...payload,
+          id: existing.id,
+          updatedAt: new Date().toISOString(),
+          settings: {
+            ...existing.settings,
+            ...(payload.settings || {}),
+          },
+          players: Array.isArray(payload.players) ? payload.players : existing.players,
+        };
+        sessions[index] = updated;
+        await writeSessions(sessions);
+        sendJson(res, 200, updated);
+      } catch (error) {
+        console.error('Failed to update session', error);
+        sendJson(res, 400, { message: 'Invalid JSON payload' });
+      }
+      return;
+    }
+  }
+
+  res.writeHead(405, { 'Content-Type': 'application/json; charset=utf-8' });
+  res.end(JSON.stringify({ message: 'Method not allowed' }));
+}
+
+const server = http.createServer(async (req, res) => {
+  try {
+    const url = new URL(req.url, `http://${req.headers.host}`);
+    if (isApiRoute(url.pathname)) {
+      await handleApiRequest(req, res, url);
+      return;
+    }
+
+    let requestedPath = url.pathname;
+    if (requestedPath === '/' || requestedPath === '') {
+      requestedPath = '/index.html';
+    }
+
+    const absolutePath = path.join(ROOT_DIR, requestedPath);
+    const normalizedPath = path.normalize(absolutePath);
+    if (!normalizedPath.startsWith(ROOT_DIR)) {
+      res.writeHead(403, { 'Content-Type': 'text/plain; charset=utf-8' });
+      res.end('Forbidden');
+      return;
+    }
+
+    serveStaticFile(res, normalizedPath);
+  } catch (error) {
+    console.error('Unexpected server error', error);
+    res.writeHead(500, { 'Content-Type': 'application/json; charset=utf-8' });
+    res.end(JSON.stringify({ message: 'Internal server error' }));
+  }
+});
+
+server.listen(PORT, () => {
+  console.log(`Poker Face Tracker server running on http://localhost:${PORT}`);
+});

--- a/styles.css
+++ b/styles.css
@@ -339,8 +339,8 @@ tbody tr:hover {
 }
 
 #table-delta.alert {
-  color: #f87171;
-  background: rgba(248, 113, 113, 0.16);
+  color: #dc2626;
+  background: rgba(220, 38, 38, 0.18);
   padding: 0.3rem 0.6rem;
   border-radius: 8px;
   display: inline-block;
@@ -350,6 +350,45 @@ tbody tr:hover {
   display: grid;
   gap: 1rem;
   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.scoreboard-header {
+  align-items: flex-start;
+}
+
+.scoreboard-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: flex-end;
+}
+
+.scoreboard-filters label {
+  min-width: 140px;
+}
+
+.scoreboard-leaders {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+  margin-bottom: 1.25rem;
+}
+
+.scoreboard-leaders .summary-card {
+  height: 100%;
+}
+
+.scoreboard-leaders .metric {
+  font-size: 1.4rem;
+}
+
+#scoreboard-table .empty {
+  text-align: center;
+  color: var(--muted);
+}
+
+#scoreboard-note {
+  margin-top: 1rem;
 }
 
 .summary-card {
@@ -412,5 +451,13 @@ button:disabled {
   .settings-toggle {
     top: 1rem;
     left: 1rem;
+  }
+
+  .scoreboard-filters {
+    width: 100%;
+  }
+
+  .scoreboard-filters label {
+    flex: 1 1 140px;
   }
 }

--- a/styles.css
+++ b/styles.css
@@ -1,14 +1,15 @@
 :root {
-  --bg: #111827;
-  --card: #1f2937;
-  --card-alt: #111827;
-  --text: #f9fafb;
-  --muted: #9ca3af;
-  --accent: #8b5cf6;
-  --accent-dark: #7c3aed;
-  --danger: #f87171;
-  --success: #34d399;
-  --border: rgba(255, 255, 255, 0.08);
+  --bg: #02110d;
+  --bg-mid: #0a3c2c;
+  --felt: #0f6041;
+  --card: rgba(5, 35, 25, 0.92);
+  --text: #f5f2e6;
+  --muted: #c6d8cb;
+  --accent: #d4af37;
+  --accent-dark: #b88910;
+  --danger: #ff6b6b;
+  --success: #6ee7b7;
+  --border: rgba(212, 175, 55, 0.24);
   --radius: 12px;
   font-size: 16px;
 }
@@ -19,12 +20,40 @@
 
 body {
   margin: 0;
-  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  background: radial-gradient(circle at top, #1e293b, var(--bg));
+  font-family: "Montserrat", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  background: radial-gradient(circle at 20% 20%, var(--felt), var(--bg));
   color: var(--text);
   min-height: 100vh;
   padding: 1.5rem;
   position: relative;
+  overflow-x: hidden;
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  background:
+    radial-gradient(circle at 5% 15%, rgba(255, 255, 255, 0.05) 0, rgba(255, 255, 255, 0) 55%),
+    radial-gradient(circle at 90% 80%, rgba(255, 215, 0, 0.06) 0, rgba(255, 215, 0, 0) 60%),
+    repeating-linear-gradient(
+      45deg,
+      rgba(8, 50, 36, 0.25) 0,
+      rgba(8, 50, 36, 0.25) 6px,
+      rgba(2, 17, 13, 0.35) 6px,
+      rgba(2, 17, 13, 0.35) 14px
+    );
+  pointer-events: none;
+  z-index: -2;
+}
+
+body::after {
+  content: "";
+  position: fixed;
+  inset: 0;
+  background: radial-gradient(circle at 75% 30%, rgba(255, 215, 0, 0.08), transparent 55%);
+  pointer-events: none;
+  z-index: -1;
 }
 
 main.app {
@@ -55,11 +84,22 @@ h1 {
 }
 
 .card {
-  background: rgba(31, 41, 55, 0.95);
+  background: linear-gradient(160deg, rgba(7, 44, 31, 0.92), rgba(3, 24, 18, 0.95));
   border-radius: var(--radius);
   padding: 1.5rem;
   border: 1px solid var(--border);
-  box-shadow: 0 10px 40px rgba(15, 23, 42, 0.45);
+  box-shadow: 0 18px 45px rgba(2, 15, 11, 0.6);
+  position: relative;
+  overflow: hidden;
+}
+
+.card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top right, rgba(212, 175, 55, 0.16), transparent 55%);
+  opacity: 0.9;
+  pointer-events: none;
 }
 
 .event-details {
@@ -90,24 +130,24 @@ h1 {
 .session-status {
   padding: 0.35rem 0.75rem;
   border-radius: 999px;
-  background: rgba(34, 197, 94, 0.16);
-  color: #4ade80;
+  background: rgba(110, 231, 183, 0.16);
+  color: var(--success);
   font-weight: 600;
-  border: 1px solid rgba(34, 197, 94, 0.35);
+  border: 1px solid rgba(110, 231, 183, 0.35);
 }
 
 .session-status.closed {
-  background: rgba(248, 113, 113, 0.18);
-  color: #fca5a5;
-  border-color: rgba(248, 113, 113, 0.45);
+  background: rgba(255, 107, 107, 0.18);
+  color: var(--danger);
+  border-color: rgba(255, 107, 107, 0.45);
 }
 
 .player-banner {
-  background: rgba(59, 130, 246, 0.12);
-  border: 1px solid rgba(59, 130, 246, 0.4);
+  background: rgba(212, 175, 55, 0.12);
+  border: 1px solid rgba(212, 175, 55, 0.4);
   border-radius: var(--radius);
   padding: 1rem 1.25rem;
-  color: #bfdbfe;
+  color: #f8e7a2;
 }
 
 .section-header {
@@ -187,25 +227,26 @@ button {
 
 button.primary {
   background: linear-gradient(135deg, var(--accent), var(--accent-dark));
-  color: white;
-  box-shadow: 0 10px 25px rgba(124, 58, 237, 0.35);
+  color: #120b04;
+  font-weight: 600;
+  box-shadow: 0 12px 28px rgba(212, 175, 55, 0.35);
 }
 
 button.primary:hover,
 button.primary:focus-visible {
   transform: translateY(-1px);
-  box-shadow: 0 12px 30px rgba(124, 58, 237, 0.5);
+  box-shadow: 0 16px 34px rgba(212, 175, 55, 0.45);
 }
 
 button.ghost {
-  background: rgba(148, 163, 184, 0.08);
+  background: rgba(198, 216, 203, 0.08);
   color: var(--text);
-  border: 1px solid rgba(148, 163, 184, 0.15);
+  border: 1px solid rgba(198, 216, 203, 0.2);
 }
 
 button.ghost:hover,
 button.ghost:focus-visible {
-  background: rgba(148, 163, 184, 0.15);
+  background: rgba(198, 216, 203, 0.18);
 }
 
 .table-wrapper {
@@ -219,14 +260,14 @@ button.ghost:focus-visible {
   width: 46px;
   height: 46px;
   border-radius: 14px;
-  background: rgba(15, 23, 42, 0.85);
-  border: 1px solid rgba(148, 163, 184, 0.15);
+  background: rgba(3, 30, 21, 0.85);
+  border: 1px solid rgba(212, 175, 55, 0.25);
   display: flex;
   flex-direction: column;
   justify-content: center;
   gap: 6px;
   padding: 0.75rem;
-  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.4);
+  box-shadow: 0 18px 30px rgba(2, 15, 11, 0.55);
   z-index: 20;
 }
 
@@ -245,9 +286,9 @@ button.ghost:focus-visible {
   position: fixed;
   inset: 0 auto 0 0;
   width: min(320px, 85vw);
-  background: rgba(15, 23, 42, 0.96);
-  border-right: 1px solid rgba(148, 163, 184, 0.18);
-  box-shadow: 20px 0 40px rgba(15, 23, 42, 0.65);
+  background: rgba(5, 36, 25, 0.97);
+  border-right: 1px solid rgba(212, 175, 55, 0.25);
+  box-shadow: 20px 0 48px rgba(2, 15, 11, 0.7);
   transform: translateX(-100%);
   transition: transform 0.3s ease;
   padding: 1.5rem;
@@ -284,7 +325,7 @@ button.ghost:focus-visible {
 .settings-overlay {
   position: fixed;
   inset: 0;
-  background: rgba(15, 23, 42, 0.65);
+  background: rgba(2, 17, 13, 0.65);
   opacity: 0;
   pointer-events: none;
   transition: opacity 0.25s ease;
@@ -303,14 +344,14 @@ table {
 }
 
 thead {
-  background: rgba(15, 23, 42, 0.85);
+  background: rgba(5, 35, 25, 0.85);
 }
 
 th,
 td {
   text-align: left;
   padding: 0.75rem 0.9rem;
-  border-bottom: 1px solid rgba(148, 163, 184, 0.15);
+  border-bottom: 1px solid rgba(198, 216, 203, 0.18);
 }
 
 th {
@@ -322,7 +363,7 @@ th {
 }
 
 tbody tr:hover {
-  background: rgba(79, 70, 229, 0.08);
+  background: rgba(212, 175, 55, 0.08);
 }
 
 .net-result.positive {
@@ -339,8 +380,8 @@ tbody tr:hover {
 }
 
 #table-delta.alert {
-  color: #dc2626;
-  background: rgba(220, 38, 38, 0.18);
+  color: #ff4d4f;
+  background: rgba(255, 77, 79, 0.2);
   padding: 0.3rem 0.6rem;
   border-radius: 8px;
   display: inline-block;
@@ -350,6 +391,27 @@ tbody tr:hover {
   display: grid;
   gap: 1rem;
   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.summary-card {
+  background: rgba(4, 32, 22, 0.88);
+  border-radius: var(--radius);
+  padding: 1.25rem;
+  border: 1px solid rgba(212, 175, 55, 0.18);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.03);
+}
+
+.summary-card h3 {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  color: rgba(248, 231, 162, 0.8);
+  margin-bottom: 0.75rem;
+}
+
+.summary-card .metric {
+  font-size: clamp(1.4rem, 2vw, 1.75rem);
+  font-weight: 700;
 }
 
 .scoreboard-header {
@@ -376,18 +438,110 @@ tbody tr:hover {
 
 .scoreboard-summary {
   display: grid;
-  gap: 0.4rem;
+  gap: 1rem;
   margin-bottom: 1.25rem;
-  padding: 0.75rem 1rem;
-  border-radius: 12px;
-  background: rgba(15, 23, 42, 0.35);
-  border: 1px solid rgba(148, 163, 184, 0.15);
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }
 
-.scoreboard-summary p {
+.summary-brick {
+  background: rgba(6, 44, 31, 0.95);
+  border-radius: 18px;
+  padding: 1.5rem;
+  border: 1px solid rgba(212, 175, 55, 0.22);
+  box-shadow: 0 12px 28px rgba(2, 15, 11, 0.45);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.summary-brick h3 {
+  margin: 0;
+  font-size: 0.95rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: rgba(248, 231, 162, 0.85);
+}
+
+.summary-brick .metric {
+  margin: 0;
+  font-size: clamp(1.6rem, 2.6vw, 2rem);
+  font-weight: 700;
+}
+
+.summary-brick .detail {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--muted);
+}
+
+.summary-brick .detail.positive {
+  color: var(--success);
+}
+
+.summary-brick .detail.negative {
+  color: var(--danger);
+}
+
+.movement-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.movement-summary {
   margin: 0;
   font-size: 0.85rem;
+  color: rgba(248, 231, 162, 0.8);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.movement-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.movement-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 0.85rem;
+  border: 1px solid transparent;
+  text-transform: none;
+}
+
+.movement-up {
+  background: rgba(110, 231, 183, 0.15);
+  color: var(--success);
+  border-color: rgba(110, 231, 183, 0.35);
+}
+
+.movement-down {
+  background: rgba(255, 107, 107, 0.18);
+  color: var(--danger);
+  border-color: rgba(255, 107, 107, 0.4);
+}
+
+.movement-neutral {
+  background: rgba(212, 175, 55, 0.16);
+  color: rgba(248, 231, 162, 0.95);
+  border-color: rgba(212, 175, 55, 0.3);
+}
+
+.movement-out {
+  background: rgba(128, 90, 213, 0.16);
+  color: #d4c8ff;
+  border-color: rgba(128, 90, 213, 0.35);
+}
+
+.movement-empty {
+  margin: 0;
   color: var(--muted);
+  font-size: 0.9rem;
 }
 
 .scoreboard-leaders .summary-card {
@@ -405,21 +559,6 @@ tbody tr:hover {
 
 #scoreboard-note {
   margin-top: 1rem;
-}
-
-.summary-card {
-  background: rgba(15, 23, 42, 0.6);
-  border-radius: 12px;
-  padding: 1rem 1.25rem;
-  border: 1px solid rgba(148, 163, 184, 0.1);
-}
-
-.summary-card h3 {
-  margin-top: 0;
-  font-size: 0.95rem;
-  color: var(--muted);
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
 }
 
 .metric {

--- a/styles.css
+++ b/styles.css
@@ -374,6 +374,22 @@ tbody tr:hover {
   margin-bottom: 1.25rem;
 }
 
+.scoreboard-summary {
+  display: grid;
+  gap: 0.4rem;
+  margin-bottom: 1.25rem;
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.35);
+  border: 1px solid rgba(148, 163, 184, 0.15);
+}
+
+.scoreboard-summary p {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
 .scoreboard-leaders .summary-card {
   height: 100%;
 }


### PR DESCRIPTION
## Summary
- replace the Express backend with a dependency-free Node HTTP server that serves the API and static assets
- add a seeding script that loads three sessions (including five active players) and tweak the red table-delta highlight
- refresh the README and npm scripts to document the new workflow and demo data reset

## Testing
- npm run seed
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68d919a15d948329829959c5b4a9d000