### PR TITLE
Add session upsert and ID tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Connection string used by the server, CLI utilities, and Kubernetes manifests
+DATABASE_URL=postgresql://pokerface:supersecret@localhost:5432/pokerface
+
+# Optional: override when the psql binary lives outside of $PATH
+# PSQL_PATH=/usr/bin/psql

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+node_modules
+npm-debug.log*
+.env
+.env.local
+.DS_Store
+coverage
+*.log
+/data/historicalSessions.csv
+/data/*.xlsx

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,14 @@
-# Use an official Node.js runtime as a parent image
 FROM node:20-alpine
 
-# Create app directory
+RUN apk add --no-cache postgresql-client
+
 WORKDIR /app
 
-# Install app dependencies
 COPY package*.json ./
-RUN npm install --production
+RUN npm install --omit=dev
 
-# Bundle app source
 COPY . .
 
-# Expose the port the app runs on
-EXPOSE 80
+EXPOSE 3000
 
-# Create volume mount point for persisted session data
-VOLUME ["/app/data"]
-
-# Run the application
 CMD ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -92,6 +92,33 @@ kubectl apply -f k8s/app.yaml
 
 If you need to change the default credentials or database name, edit the `stringData` block inside `k8s/app.yaml` before applying. Kubernetes will regenerate the base64-encoded secret data automatically.
 
+### Troubleshooting Kubernetes validation
+
+The manifest itself does not require any extra flags, but `kubectl` must be connected to a running cluster so it can download the API server's OpenAPI schema during validation. If you see an error similar to the following:
+
+```
+error validating "app.yaml": error validating data: failed to download openapi: Get "https://127.0.0.1:51240/openapi/v2?timeout=32s": dial tcp 127.0.0.1:51240: connectex: No connection could be made because the target machine actively refused it
+```
+
+your kubeconfig is pointing at an API server that is unreachable (for example, Docker Desktop Kubernetes is stopped, or `minikube` is not running). Fix the context rather than editing `app.yaml`:
+
+1. Check your current context and ensure it matches the cluster you intend to use:
+
+   ```bash
+   kubectl config current-context
+   ```
+
+2. Start or connect to that cluster (`minikube start`, enabling Kubernetes in Docker Desktop, `kind create cluster`, etc.).
+
+3. Verify connectivity:
+
+   ```bash
+   kubectl cluster-info
+   kubectl get nodes
+   ```
+
+Once the API server is reachable, rerun `kubectl apply -f k8s/app.yaml` and the validation step will succeed without modifying the manifest.
+
 ## Branching
 
 All development now lives on the `main` branch. Previous working branches have been consolidated so you can pull directly from `main` to receive the latest tracker updates.

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ With the container running, browse to http://localhost:3000 to access the app.
 
 The `k8s/app.yaml` manifest now provisions the entire stack—namespace, shared secret, PostgreSQL `StatefulSet`, and the Poker Face deployment. The secret seeds a `DATABASE_URL` that already points at the in-cluster PostgreSQL service (`pokerface-postgres.pokerface.svc.cluster.local`), so the application talks to the database automatically as soon as both pods are up.
 
-After pushing your container image to a registry that the cluster can reach, apply the manifest in one step:
+The manifest references the public `sujaz/poker:latest` image on Docker Hub, so you can apply it immediately without building a custom image. If you prefer to run your own build, push it to a registry the cluster can reach and edit the `image` field in `k8s/app.yaml` before deploying. Once you're ready, apply the manifest in one step:
 
 ```bash
 kubectl apply -f k8s/app.yaml

--- a/README.md
+++ b/README.md
@@ -1,32 +1,68 @@
 # Poker Night Tracker
 
-A full-stack poker night companion that lets hosts coordinate sessions, track cash movement, and review historical performance.
+A full-stack poker night companion that lets hosts coordinate sessions, track cash movement, and review historical performance. Session state now lives in PostgreSQL so it can be shared by multiple app replicas inside Kubernetes.
 
 ## Features
 
 - Slide-out settings drawer with host controls for name, location, date/time, preferred currency (USD, EUR, or ILS), reported totals, and table expenses.
 - Session lifecycle management: administrators can open/close a night, and once closed, player inputs are locked until a fresh session begins.
 - Shareable player registration mode (`?role=player`) so guests can enter their buy-ins and cash-out amounts while the event remains open.
-- Persistent session archive stored on disk (`data/sessions.json`) so every night is saved for future reference.
+- Persistent session archive stored in PostgreSQL so every night is saved for future reference.
 - Historical scoreboard that surfaces the most profitable player and win leaders per session, by year, or across all time, complete with filterable tables.
 - Real-time summary metrics: total buy-ins, total cash out, table delta (highlighted bright red when not balanced), expense totals, and cumulative wins/losses.
 
 ## Getting started
 
-No external dependencies are required—the server is built on Node's core modules. Populate the sample data, then launch the tracker:
+1. Copy the example environment file and set the `DATABASE_URL` that points at your PostgreSQL instance (the built-in scripts use the `psql` CLI, so make sure it is installed):
 
-```bash
-npm run seed   # creates data/sessions.json with 3 sessions and 5 active players
-npm start
+   ```bash
+   cp .env.example .env
+   ```
+
+2. Start PostgreSQL locally or in Docker:
+
+   ```bash
+   docker run --rm -p 5432:5432 \
+     -e POSTGRES_PASSWORD=supersecret \
+     -e POSTGRES_USER=pokerface \
+     -e POSTGRES_DB=pokerface \
+     --name pokerface-db postgres:15-alpine
+   ```
+
+3. Run the schema migration and load seed data (optional):
+
+   ```bash
+   npm run migrate
+   npm run seed
+   ```
+
+4. Start the tracker and open http://localhost:3000:
+
+   ```bash
+   npm start
+   ```
+
+Sessions and player data are written to PostgreSQL. Each update is saved automatically while a session is open, and closing a session locks it into the archive so you can compare past results from the scoreboard.
+
+## Importing the historical Google Sheet
+
+Export the Google Sheet (`1mgjOcoFy3XRieHbR5LAjRwZdDKHzHLhpL5OtBIV5IDw`) to CSV and save it as `data/historicalSessions.csv`. The importer expects the following headers:
+
+```
+sessionId,playerId,playerName,buyins,final,hostName,location,datetime,expenses,reportedFinal,currency,status
 ```
 
-Then open http://localhost:3000 in your browser.
+Each row represents a player entry for a given session; the script groups rows by `sessionId` before inserting them. Once the CSV is in place, run:
 
-Sessions and player data are written to `data/sessions.json`. Each update is saved automatically while a session is open, and closing a session locks it into the archive so you can compare past results from the scoreboard. Re-run `npm run seed` at any time to restore the demo data.
+```bash
+npm run import:sessions
+```
+
+The repo includes `data/historicalSessions.sample.csv` that demonstrates the layout. Because the CI environment cannot reach Google Sheets directly, place the exported CSV in `data/historicalSessions.csv` before running the import command.
 
 ## Running with Docker
 
-You can also run the tracker in a container using the provided `Dockerfile`.
+You can also run the tracker in a container using the provided `Dockerfile`. The image bundles the `psql` client so it can reach an external PostgreSQL database defined by `DATABASE_URL`.
 
 1. Build the image:
 
@@ -34,15 +70,27 @@ You can also run the tracker in a container using the provided `Dockerfile`.
    docker build -t poker-night-tracker .
    ```
 
-2. Launch the container and expose port 3000. Mount a local directory to persist session history between runs:
+2. Launch the container and expose port 3000. Provide a `DATABASE_URL` so the app can talk to PostgreSQL (running locally or elsewhere):
 
    ```bash
-   docker run --rm -p 3000:3000 -v "$(pwd)/data:/app/data" poker-night-tracker
+   docker run --rm -p 3000:3000 \
+     -e DATABASE_URL=postgresql://pokerface:supersecret@host.docker.internal:5432/pokerface \
+     poker-night-tracker
    ```
 
-   On Windows PowerShell, use `${PWD}` instead of `$(pwd)` for the bind mount path.
+With the container running, browse to http://localhost:3000 to access the app.
 
-With the container running, browse to http://localhost:3000 to access the app. All session data remains in your mounted `data` directory so historical results survive container restarts.
+## Kubernetes deployment
+
+The `k8s/app.yaml` manifest now provisions the entire stack—namespace, shared secret, PostgreSQL `StatefulSet`, and the Poker Face deployment. The secret seeds a `DATABASE_URL` that already points at the in-cluster PostgreSQL service (`pokerface-postgres.pokerface.svc.cluster.local`), so the application talks to the database automatically as soon as both pods are up.
+
+After pushing your container image to a registry that the cluster can reach, apply the manifest in one step:
+
+```bash
+kubectl apply -f k8s/app.yaml
+```
+
+If you need to change the default credentials or database name, edit the `stringData` block inside `k8s/app.yaml` before applying. Kubernetes will regenerate the base64-encoded secret data automatically.
 
 ## Branching
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ With the container running, browse to http://localhost:3000 to access the app.
 
 The `k8s/app.yaml` manifest now provisions the entire stack—namespace, shared secret, PostgreSQL `StatefulSet`, and the Poker Face deployment. The secret seeds a `DATABASE_URL` that already points at the in-cluster PostgreSQL service (`pokerface-postgres.pokerface.svc.cluster.local`), so the application talks to the database automatically as soon as both pods are up.
 
-The manifest references the public `sujaz/poker:latest` image on Docker Hub, so you can apply it immediately without building a custom image. If you prefer to run your own build, push it to a registry the cluster can reach and edit the `image` field in `k8s/app.yaml` before deploying. Once you're ready, apply the manifest in one step:
+The manifest references the public `sujaz/poker:latest` image on Docker Hub, so you can apply it immediately without building a custom image or running `docker login`. If you prefer to run your own build, push it to a registry the cluster can reach and edit the `image` field in `k8s/app.yaml` before deploying. Once you're ready, apply the manifest in one step:
 
 ```bash
 kubectl apply -f k8s/app.yaml
@@ -118,6 +118,17 @@ your kubeconfig is pointing at an API server that is unreachable (for example, D
    ```
 
 Once the API server is reachable, rerun `kubectl apply -f k8s/app.yaml` and the validation step will succeed without modifying the manifest.
+
+### Troubleshooting image pulls
+
+Pods should always pull the latest public image thanks to the `imagePullPolicy: Always` directive in `k8s/app.yaml`. If `kubectl describe pod` shows an `ImagePullBackOff` referencing `your-registry/pokerface:latest`, the cluster is still running an older deployment definition. Reapply the manifest (or delete the existing deployment before reapplying) so Kubernetes sees the updated `sujaz/poker:latest` reference:
+
+```bash
+kubectl delete deployment pokerface-app -n pokerface || true
+kubectl apply -f k8s/app.yaml
+```
+
+When the pods restart, `kubectl get pods -n pokerface` should report them as `Running` and `kubectl describe pod` will show pulls succeeding without any registry credentials.
 
 ## Branching
 

--- a/data/historicalSessions.sample.csv
+++ b/data/historicalSessions.sample.csv
@@ -1,0 +1,14 @@
+sessionId,playerId,playerName,buyins,final,hostName,location,datetime,expenses,reportedFinal,currency,status
+session-2025-main,player-alex,Alex Morgan,400,525,Jamie Rivera,Skyline Loft,2025-01-15T20:00:00Z,150,2800,USD,open
+session-2025-main,player-bree,Bree Chen,300,180,Jamie Rivera,Skyline Loft,2025-01-15T20:00:00Z,150,2800,USD,open
+session-2025-main,player-cam,Cam Patel,250,420,Jamie Rivera,Skyline Loft,2025-01-15T20:00:00Z,150,2800,USD,open
+session-2025-main,player-dev,Devon Price,500,760,Jamie Rivera,Skyline Loft,2025-01-15T20:00:00Z,150,2800,USD,open
+session-2025-main,player-eden,Eden Solis,350,290,Jamie Rivera,Skyline Loft,2025-01-15T20:00:00Z,150,2800,USD,open
+session-2024-holiday,player-alex-2024,Alex Morgan,450,610,Jamie Rivera,Mountain Retreat,2024-12-19T20:30:00Z,120,2400,EUR,closed
+session-2024-holiday,player-bree-2024,Bree Chen,300,250,Jamie Rivera,Mountain Retreat,2024-12-19T20:30:00Z,120,2400,EUR,closed
+session-2024-holiday,player-fern-2024,Fernando Ortiz,280,360,Jamie Rivera,Mountain Retreat,2024-12-19T20:30:00Z,120,2400,EUR,closed
+session-2024-holiday,player-ida-2024,Ida Novak,320,260,Jamie Rivera,Mountain Retreat,2024-12-19T20:30:00Z,120,2400,EUR,closed
+session-2023-spring,player-cam-2023,Cam Patel,260,480,Jamie Rivera,Riverfront Condo,2023-04-09T19:45:00Z,95,2100,USD,closed
+session-2023-spring,player-dev-2023,Devon Price,420,340,Jamie Rivera,Riverfront Condo,2023-04-09T19:45:00Z,95,2100,USD,closed
+session-2023-spring,player-fern-2023,Fernando Ortiz,200,260,Jamie Rivera,Riverfront Condo,2023-04-09T19:45:00Z,95,2100,USD,closed
+session-2023-spring,player-gia-2023,Gia Walters,280,320,Jamie Rivera,Riverfront Condo,2023-04-09T19:45:00Z,95,2100,USD,closed

--- a/db/index.js
+++ b/db/index.js
@@ -1,0 +1,189 @@
+const { execFile } = require('child_process');
+const { generateId } = require('../utils/ids');
+const { loadEnv } = require('../loadEnv');
+
+loadEnv();
+
+const DATABASE_URL = process.env.DATABASE_URL;
+const PSQL_PATH = process.env.PSQL_PATH || 'psql';
+const MAX_BUFFER = 10 * 1024 * 1024;
+
+if (!DATABASE_URL) {
+  console.warn('DATABASE_URL is not defined. Database operations will fail until it is configured.');
+}
+
+function execPsql(sql) {
+  return new Promise((resolve, reject) => {
+    if (!DATABASE_URL) {
+      reject(new Error('DATABASE_URL environment variable is not configured.'));
+      return;
+    }
+
+    const args = ['-X', '--tuples-only', '--no-align', '--set', 'ON_ERROR_STOP=1', '-d', DATABASE_URL, '-c', sql];
+    execFile(PSQL_PATH, args, { maxBuffer: MAX_BUFFER }, (error, stdout, stderr) => {
+      if (error) {
+        const details = new Error(stderr || error.message);
+        details.stack = error.stack;
+        reject(details);
+        return;
+      }
+      resolve(stdout.trim());
+    });
+  });
+}
+
+const SCHEMA_SQL = `
+CREATE TABLE IF NOT EXISTS sessions (
+  id TEXT PRIMARY KEY,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  settings JSONB NOT NULL DEFAULT '{}'::jsonb,
+  players JSONB NOT NULL DEFAULT '[]'::jsonb
+);
+CREATE INDEX IF NOT EXISTS sessions_created_at_idx ON sessions (created_at DESC);
+`;
+
+let schemaReadyPromise;
+function ensureDatabase() {
+  if (!schemaReadyPromise) {
+    schemaReadyPromise = execPsql(SCHEMA_SQL);
+  }
+  return schemaReadyPromise;
+}
+
+function sqlLiteral(value) {
+  if (value === null || value === undefined) {
+    return 'NULL';
+  }
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return String(value);
+  }
+  if (typeof value === 'boolean') {
+    return value ? 'TRUE' : 'FALSE';
+  }
+  return `'${String(value).replace(/'/g, "''")}'`;
+}
+
+function jsonLiteral(value) {
+  return `${sqlLiteral(JSON.stringify(value))}::jsonb`;
+}
+
+function normalizeSession(row) {
+  if (!row) {
+    return null;
+  }
+  return {
+    id: row.id,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    settings: row.settings || {},
+    players: Array.isArray(row.players) ? row.players : [],
+  };
+}
+
+function buildSessionPayload(payload = {}) {
+  const timestamp = new Date().toISOString();
+  const settings = {
+    hostName: '',
+    location: '',
+    datetime: '',
+    expenses: '',
+    reportedFinal: '',
+    currency: 'USD',
+    sessionStatus: 'open',
+    ...(payload.settings || {}),
+  };
+
+  const players = Array.isArray(payload.players) ? payload.players : [];
+
+  return {
+    id: payload.id || generateId('session'),
+    createdAt: payload.createdAt || timestamp,
+    updatedAt: payload.updatedAt || timestamp,
+    settings,
+    players,
+  };
+}
+
+async function getSessions() {
+  await ensureDatabase();
+  const sql = `SELECT COALESCE(json_agg(row_to_json(s)), '[]'::json) FROM (SELECT id, created_at, updated_at, settings, players FROM sessions ORDER BY created_at DESC) AS s;`;
+  const payload = await execPsql(sql);
+  return JSON.parse(payload || '[]').map(normalizeSession);
+}
+
+async function getSessionById(id) {
+  await ensureDatabase();
+  const sql = `SELECT row_to_json(s) FROM (SELECT id, created_at, updated_at, settings, players FROM sessions WHERE id = ${sqlLiteral(id)} LIMIT 1) AS s;`;
+  const payload = await execPsql(sql);
+  if (!payload) {
+    return null;
+  }
+  const parsed = JSON.parse(payload);
+  if (!parsed) {
+    return null;
+  }
+  return normalizeSession(parsed);
+}
+
+async function createSession(payload) {
+  const session = buildSessionPayload(payload);
+  await ensureDatabase();
+  const sql = `
+    INSERT INTO sessions (id, created_at, updated_at, settings, players)
+    VALUES (
+      ${sqlLiteral(session.id)},
+      ${sqlLiteral(session.createdAt)},
+      ${sqlLiteral(session.updatedAt)},
+      ${jsonLiteral(session.settings)},
+      ${jsonLiteral(session.players)}
+    )
+    ON CONFLICT (id) DO UPDATE SET
+      updated_at = EXCLUDED.updated_at,
+      settings = EXCLUDED.settings,
+      players = EXCLUDED.players
+    RETURNING row_to_json(sessions.*);
+  `;
+  const inserted = await execPsql(sql);
+  return normalizeSession(JSON.parse(inserted));
+}
+
+async function updateSession(id, payload) {
+  const existing = await getSessionById(id);
+  if (!existing) {
+    return null;
+  }
+  const merged = buildSessionPayload({
+    ...existing,
+    ...payload,
+    id: existing.id,
+    createdAt: existing.createdAt,
+    updatedAt: new Date().toISOString(),
+    settings: {
+      ...existing.settings,
+      ...(payload.settings || {}),
+    },
+    players: Array.isArray(payload.players) ? payload.players : existing.players,
+  });
+
+  await ensureDatabase();
+  const sql = `
+    UPDATE sessions
+    SET
+      updated_at = ${sqlLiteral(merged.updatedAt)},
+      settings = ${jsonLiteral(merged.settings)},
+      players = ${jsonLiteral(merged.players)}
+    WHERE id = ${sqlLiteral(merged.id)}
+    RETURNING row_to_json(sessions.*);
+  `;
+  const updated = await execPsql(sql);
+  return normalizeSession(JSON.parse(updated));
+}
+
+module.exports = {
+  ensureDatabase,
+  getSessions,
+  getSessionById,
+  createSession,
+  updateSession,
+};

--- a/k8s/app.yaml
+++ b/k8s/app.yaml
@@ -103,7 +103,7 @@ spec:
       containers:
         - name: pokerface-app
           image: sujaz/poker:latest
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           env:
             - name: DATABASE_URL
               valueFrom:

--- a/k8s/app.yaml
+++ b/k8s/app.yaml
@@ -1,0 +1,142 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: pokerface
+  labels:
+    app: pokerface
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: pokerface-db-secret
+  namespace: pokerface
+  labels:
+    app: pokerface
+stringData:
+  POSTGRES_DB: pokerface
+  POSTGRES_USER: pokerface
+  POSTGRES_PASSWORD: supersecret
+  DATABASE_URL: postgres://pokerface:supersecret@pokerface-postgres.pokerface.svc.cluster.local:5432/pokerface
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pokerface-postgres
+  namespace: pokerface
+  labels:
+    app: pokerface-postgres
+spec:
+  type: LoadBalancer
+  selector:
+    app: pokerface-postgres
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: 5432
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: pokerface-postgres
+  namespace: pokerface
+spec:
+  serviceName: pokerface-postgres
+  replicas: 1
+  selector:
+    matchLabels:
+      app: pokerface-postgres
+  template:
+    metadata:
+      labels:
+        app: pokerface-postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:15-alpine
+          ports:
+            - containerPort: 5432
+          env:
+            - name: POSTGRES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: pokerface-db-secret
+                  key: POSTGRES_DB
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: pokerface-db-secret
+                  key: POSTGRES_USER
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: pokerface-db-secret
+                  key: POSTGRES_PASSWORD
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 5Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pokerface-app
+  namespace: pokerface
+  labels:
+    app: pokerface-app
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: pokerface-app
+  template:
+    metadata:
+      labels:
+        app: pokerface-app
+    spec:
+      containers:
+        - name: pokerface-app
+          image: your-registry/pokerface:latest
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: pokerface-db-secret
+                  key: DATABASE_URL
+          ports:
+            - containerPort: 3000
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 3000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 3000
+            initialDelaySeconds: 15
+            periodSeconds: 20
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pokerface-app
+  namespace: pokerface
+  labels:
+    app: pokerface-app
+spec:
+  type: ClusterIP
+  selector:
+    app: pokerface-app
+  ports:
+    - name: http
+      port: 80
+      targetPort: 3000

--- a/k8s/app.yaml
+++ b/k8s/app.yaml
@@ -102,7 +102,7 @@ spec:
     spec:
       containers:
         - name: pokerface-app
-          image: your-registry/pokerface:latest
+          image: sujaz/poker:latest
           imagePullPolicy: IfNotPresent
           env:
             - name: DATABASE_URL

--- a/k8s/app.yaml
+++ b/k8s/app.yaml
@@ -91,7 +91,7 @@ metadata:
   labels:
     app: pokerface-app
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       app: pokerface-app
@@ -102,7 +102,7 @@ spec:
     spec:
       containers:
         - name: pokerface-app
-          image: sujaz/poker:latest
+          image: sujaz/poker:0.0.2
           imagePullPolicy: Always
           env:
             - name: DATABASE_URL
@@ -133,7 +133,7 @@ metadata:
   labels:
     app: pokerface-app
 spec:
-  type: ClusterIP
+  type: LoadBalancer
   selector:
     app: pokerface-app
   ports:

--- a/loadEnv.js
+++ b/loadEnv.js
@@ -1,0 +1,32 @@
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * Loads variables from a local .env file without relying on external packages.
+ * Existing environment variables take precedence.
+ */
+function loadEnv() {
+  const envPath = path.join(__dirname, '.env');
+  if (!fs.existsSync(envPath)) {
+    return;
+  }
+
+  const contents = fs.readFileSync(envPath, 'utf-8');
+  contents
+    .split(/\r?\n/g)
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith('#'))
+    .forEach((line) => {
+      const idx = line.indexOf('=');
+      if (idx === -1) {
+        return;
+      }
+      const key = line.slice(0, idx).trim();
+      const value = line.slice(idx + 1).trim();
+      if (!Object.prototype.hasOwnProperty.call(process.env, key)) {
+        process.env[key] = value;
+      }
+    });
+}
+
+module.exports = { loadEnv };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,12 @@
+{
+  "name": "pokerface-tracker",
+  "version": "1.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "pokerface-tracker",
+      "version": "1.1.0"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "seed": "node scripts/seedSessions.js"
+    "migrate": "node scripts/migrate.js",
+    "seed": "node scripts/seedSessions.js",
+    "import:sessions": "node scripts/importHistoricalSessions.js",
+    "test": "node --test"
   }
 }

--- a/scripts/importHistoricalSessions.js
+++ b/scripts/importHistoricalSessions.js
@@ -1,0 +1,164 @@
+const fs = require('fs').promises;
+const path = require('path');
+const { loadEnv } = require('../loadEnv');
+const { createSession } = require('../db');
+const { generateId } = require('../utils/ids');
+
+loadEnv();
+
+const DEFAULT_FILE = path.join(__dirname, '..', 'data', 'historicalSessions.csv');
+
+function parseCsv(content) {
+  const rows = [];
+  let current = '';
+  let inQuotes = false;
+  let row = [];
+
+  for (let i = 0; i < content.length; i += 1) {
+    const char = content[i];
+
+    if (inQuotes) {
+      if (char === '"') {
+        if (content[i + 1] === '"') {
+          current += '"';
+          i += 1;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        current += char;
+      }
+      continue;
+    }
+
+    if (char === '"') {
+      inQuotes = true;
+      continue;
+    }
+
+    if (char === ',') {
+      row.push(current);
+      current = '';
+      continue;
+    }
+
+    if (char === '\r') {
+      continue;
+    }
+
+    if (char === '\n') {
+      row.push(current);
+      if (row.some((value) => value.trim() !== '')) {
+        rows.push(row);
+      }
+      row = [];
+      current = '';
+      continue;
+    }
+
+    current += char;
+  }
+
+  if (current || row.length) {
+    row.push(current);
+    if (row.some((value) => value.trim() !== '')) {
+      rows.push(row);
+    }
+  }
+
+  return rows;
+}
+
+function toObject(rows) {
+  if (!rows.length) {
+    return [];
+  }
+  const headers = rows[0].map((header) => header.trim());
+  return rows.slice(1).map((line) => {
+    const entry = {};
+    headers.forEach((header, idx) => {
+      entry[header] = line[idx] ? line[idx].trim() : '';
+    });
+    return entry;
+  });
+}
+
+function safeNumber(value) {
+  if (value === undefined || value === null || value === '') {
+    return 0;
+  }
+  const num = Number(value);
+  return Number.isFinite(num) ? num : 0;
+}
+
+function normalizeStatus(value) {
+  const lowered = (value || '').toString().toLowerCase();
+  if (lowered === 'closed' || lowered === 'open') {
+    return lowered;
+  }
+  return 'closed';
+}
+
+function parseDatetime(value) {
+  if (!value) {
+    return '';
+  }
+  const asDate = new Date(value);
+  if (Number.isNaN(asDate.getTime())) {
+    return '';
+  }
+  return asDate.toISOString();
+}
+
+async function importCsv(filePath) {
+  const absolutePath = path.resolve(filePath || DEFAULT_FILE);
+  const content = await fs.readFile(absolutePath, 'utf-8');
+  const rows = parseCsv(content);
+  const entries = toObject(rows);
+
+  const sessions = new Map();
+
+  entries.forEach((entry) => {
+    const id = entry.sessionId || entry.id || generateId('session');
+    const existing = sessions.get(id) || {
+      id,
+      settings: {
+        hostName: entry.hostName || '',
+        location: entry.location || '',
+        datetime: parseDatetime(entry.datetime),
+        expenses: safeNumber(entry.expenses),
+        reportedFinal: safeNumber(entry.reportedFinal),
+        currency: entry.currency || 'USD',
+        sessionStatus: normalizeStatus(entry.status),
+      },
+      players: [],
+      createdAt: parseDatetime(entry.createdAt) || parseDatetime(entry.datetime) || new Date().toISOString(),
+      updatedAt: parseDatetime(entry.updatedAt) || parseDatetime(entry.datetime) || new Date().toISOString(),
+    };
+
+    const playerName = entry.playerName || entry.player || '';
+    const playerId = entry.playerId || `${id}-${playerName.replace(/\s+/g, '-').toLowerCase()}`;
+    if (playerName) {
+      existing.players.push({
+        id: playerId,
+        name: playerName,
+        buyins: safeNumber(entry.buyins),
+        final: safeNumber(entry.final),
+      });
+    }
+
+    sessions.set(id, existing);
+  });
+
+  for (const session of sessions.values()) {
+    await createSession(session);
+  }
+
+  console.log(`Imported ${sessions.size} sessions from ${absolutePath}`);
+}
+
+const targetFile = process.argv[2] || DEFAULT_FILE;
+importCsv(targetFile).catch((error) => {
+  console.error('Failed to import historical sessions:', error);
+  process.exitCode = 1;
+});

--- a/scripts/migrate.js
+++ b/scripts/migrate.js
@@ -1,0 +1,13 @@
+const { loadEnv } = require('../loadEnv');
+const { ensureDatabase } = require('../db');
+
+loadEnv();
+
+ensureDatabase()
+  .then(() => {
+    console.log('Database schema ensured.');
+  })
+  .catch((error) => {
+    console.error('Migration failed:', error);
+    process.exitCode = 1;
+  });

--- a/scripts/seedSessions.js
+++ b/scripts/seedSessions.js
@@ -1,42 +1,12 @@
-const fs = require('fs').promises;
-const path = require('path');
+const { loadEnv } = require('../loadEnv');
+const { createSession } = require('../db');
 
-const DATA_DIR = path.join(__dirname, '..', 'data');
-const SESSIONS_FILE = path.join(DATA_DIR, 'sessions.json');
+loadEnv();
 
-/**
- * Creates a player entry for the seed data file.
- * @param {string} id - Stable identifier for the player.
- * @param {string} name - Display name of the player.
- * @param {number} buyins - Total buy-ins purchased.
- * @param {number} final - Final chip/cash amount.
- * @returns {{id:string,name:string,buyins:number,final:number}} Player object.
- */
 function makePlayer(id, name, buyins, final) {
-  return {
-    id,
-    name,
-    buyins,
-    final,
-  };
+  return { id, name, buyins, final };
 }
 
-/**
- * Builds a session object using simple shorthand parameters.
- * @param {Object} config - Properties describing the session.
- * @param {string} config.id - Session identifier.
- * @param {string} config.createdAt - ISO timestamp for creation.
- * @param {string} config.updatedAt - ISO timestamp for last update.
- * @param {string} config.hostName - Host name running the game.
- * @param {string} config.location - Location of the table.
- * @param {string} config.datetime - ISO timestamp of the event.
- * @param {number} config.expenses - Table expenses for the night.
- * @param {number} config.reportedFinal - Reported final cash total.
- * @param {string} config.currency - Currency code (USD/EUR/ILS).
- * @param {string} config.status - Session status flag.
- * @param {Array} config.players - Players participating in the session.
- * @returns {Object} Normalized session payload.
- */
 function sessionTemplate({
   id,
   createdAt,
@@ -67,13 +37,7 @@ function sessionTemplate({
   };
 }
 
-/**
- * Seeds the local JSON file with three representative sessions.
- * @returns {Promise<void>} Resolves once the data has been written.
- */
 async function seed() {
-  await fs.mkdir(DATA_DIR, { recursive: true });
-
   const now = new Date();
   const isoNow = now.toISOString();
   const sessions = [
@@ -134,11 +98,14 @@ async function seed() {
     }),
   ];
 
-  await fs.writeFile(SESSIONS_FILE, JSON.stringify(sessions, null, 2));
-  console.log(`Seeded ${sessions.length} sessions with ${sessions[0].players.length} active players.`);
+  for (const session of sessions) {
+    await createSession(session);
+  }
+
+  console.log(`Seeded ${sessions.length} sessions.`);
 }
 
 seed().catch((error) => {
-  console.error('Failed to seed sessions file:', error);
+  console.error('Failed to seed sessions:', error);
   process.exitCode = 1;
 });

--- a/tests/utils.ids.test.js
+++ b/tests/utils.ids.test.js
@@ -1,0 +1,14 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { generateId } = require('../utils/ids');
+
+test('generateId prefixes the identifier', () => {
+  const id = generateId('session');
+  assert.ok(id.startsWith('session-'));
+});
+
+test('generateId produces reasonably unique values', () => {
+  const ids = new Set(Array.from({ length: 100 }, () => generateId('player')));
+  assert.equal(ids.size, 100);
+});

--- a/utils/ids.js
+++ b/utils/ids.js
@@ -1,0 +1,5 @@
+function generateId(prefix = 'session') {
+  return `${prefix}-${Math.random().toString(36).slice(2)}-${Date.now()}`;
+}
+
+module.exports = { generateId };


### PR DESCRIPTION
## Summary
- prevent duplicate key errors by using an upsert when inserting sessions into PostgreSQL
- add a minimal `node --test` harness that exercises the `generateId` helper so the repository has a runnable test suite

## Testing
- npm test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c48532d7883299c4264bb50157a03)